### PR TITLE
lvalues are called places in Rust/MIR

### DIFF
--- a/reference/src/introduction.md
+++ b/reference/src/introduction.md
@@ -8,7 +8,7 @@
 * *niche*
 * *layout*
 * *tag*
-* *rvalue*
-* *lvalue*
+* *place* (or *lvalue* in C/C++ speak)
+* *rvalue* (maybe we can come up with a Rust term for this as well?)
 
 ## Unsafe abstraction


### PR DESCRIPTION
At least for anyone with a background in functional programming, calling these a "\*value" is very confusing. *Values* are the result of a computation, e.g. "5" is a value. "2+3" is not a value, it is an *expression* that evaluates/computes to the value "5".

The lvalue/rvalue distinction is on a different axis though, I think. Composing the two terminologies, we have "place expressions" like `x[3].foo`, and "place values" like (memory address) `0x00803240` -- where again "place values" are the thing that "place expressions" evaluate to. This all makes a lot of sense. If we'd stick to C(++) terminology, we would have to distinguish "lvalue expressions" and "lvalue values", and that seems just absurd.

This distinction, btw, manifests in the codebase as well: `rustc::mir::Place` is a place expression, `rustc_mir::interpret::Place` is a place value.

---

I think we should find matching terminology to replace "rvalue". Some "X" referring to the result of a computation like `2 + 3` or `*foo.bar` or `&(*x).field`. The result can be pretty much any sequence of bytes, the key factor being that you can read them (copy them into a place), but you cannot change them.

Right now, their expression form is `rustc::mir::Rvalue`, and their value form is `rustc_mir::interpret::Operand`. We could call these things "operand expression/value", if `rustc::mir::Operand` wasn't already taken to be something else ("operand expressions" are a subset of "rvalue expressions", namely they are constants or a place expression, they don't actually compute anything on the data). Any suggestions for a good noun to use here?