### PR TITLE
Clarify maximum pointer offset

### DIFF
--- a/reference/src/layout/scalars.md
+++ b/reference/src/layout/scalars.md
@@ -53,8 +53,8 @@ They have the same layout as the [pointer types] for which the pointee is
 >   usize]`. Only ZST arrays can probably be this large in practice, non-ZST
 >   arrays are bound by the maximum size of Rust values,
 >
-> * the maximum value by which a pointer can be offseted using `ptr.add(count:
->   usize)` is `usize::max_value()`.
+> * the maximum value in bytes by which a pointer can be offseted using
+>   `ptr.add` or `ptr.offset` is `isize::max_value()`.
 >
 > These limits have not gone through the RFC process and are not guaranteed to
 > hold.


### PR DESCRIPTION
This should address @comex issue in #102 . Note that we currently don't guarantee anything, the changes are just to the note describing how things work in the current implementation. Guaranteeing anything would require an RFC.