### PR TITLE
Update discriminant-elision optimization on Option-like enums

### DIFF
--- a/reference/src/glossary.md
+++ b/reference/src/glossary.md
@@ -64,7 +64,8 @@ In this document, *layout* and *representation* are not synonyms.
 The *niche* of a type determines invalid bit-patterns that will be used by layout optimizations.
 
 For example, `&mut T` has at least one niche, the "all zeros" bit-pattern. This
-niche is used by layout optimizations like "`enum` discriminant elision" to
+niche is used by layout optimizations like ["`enum` discriminant
+elision"](layout/enums.html#discriminant-elision-on-option-like-enums) to
 guarantee that `Option<&mut T>` has the same size as `&mut T`.
 
 While all niches are invalid bit-patterns, not all invalid bit-patterns are

--- a/reference/src/glossary.md
+++ b/reference/src/glossary.md
@@ -61,7 +61,7 @@ In this document, *layout* and *representation* are not synonyms.
 
 #### Niche
 
-Invalid bit-patterns that will be used by layout optimizations.
+The *niche* of a type determines invalid bit-patterns that will be used by layout optimizations.
 
 For example, `&mut T` has at least one niche, the "all zeros" bit-pattern. This
 niche is used by layout optimizations like "`enum` discriminant elision" to

--- a/reference/src/glossary.md
+++ b/reference/src/glossary.md
@@ -61,11 +61,16 @@ In this document, *layout* and *representation* are not synonyms.
 
 #### Niche
 
-Invalid bit-patters that will be used by layout optimizations.
+Invalid bit-patterns that will be used by layout optimizations.
 
 For example, `&mut T` has at least one niche, the "all zeros" bit-pattern. This
 niche is used by layout optimizations like "`enum` discriminant elision" to
 guarantee that `Option<&mut T>` has the same size as `&mut T`.
+
+While all niches are invalid bit-patterns, not all invalid bit-patterns are
+niches. For example, the "all bits uninitialized" is an invalid bit-pattern for
+`&mut T`, but this bit-pattern is not used by layout optimizations, and is not a
+niche.
 
 
 ### TODO

--- a/reference/src/glossary.md
+++ b/reference/src/glossary.md
@@ -69,7 +69,7 @@ guarantee that `Option<&mut T>` has the same size as `&mut T`.
 
 While all niches are invalid bit-patterns, not all invalid bit-patterns are
 niches. For example, the "all bits uninitialized" is an invalid bit-pattern for
-`&mut T`, but this bit-pattern is not used by layout optimizations, and is not a
+`&mut T`, but this bit-pattern cannot be used by layout optimizations, and is not a
 niche.
 
 

--- a/reference/src/glossary.md
+++ b/reference/src/glossary.md
@@ -59,9 +59,17 @@ Moreover, the layout of a type records its *function call ABI* (or just *ABI* fo
 Note: Originally, *layout* and *representation* were treated as synonyms, and Rust language features like the `#[repr]` attribute reflect this. 
 In this document, *layout* and *representation* are not synonyms.
 
+#### Niche
+
+Invalid bit-patters that will be used by layout optimizations.
+
+For example, `&mut T` has at least one niche, the "all zeros" bit-pattern. This
+niche is used by layout optimizations like "`enum` discriminant elision" to
+guarantee that `Option<&mut T>` has the same size as `&mut T`.
+
+
 ### TODO
 
-* *niche*
 * *tag*
 * *rvalue*
 * *lvalue*

--- a/reference/src/layout/enums.md
+++ b/reference/src/layout/enums.md
@@ -323,7 +323,8 @@ as a niche.
 
 The niche values of a type are parts of its validity invariant which, as of this
 writing, is the current active discussion topic in the unsafe code guidelines
-process. [rust-lang/rust#60300] specifies that the following types have a niche:
+process. [rust-lang/rust#60300] specifies that the following types have at least
+one niche (the all-zeros bit-pattern):
 
 * `&T`
 * `&mut T`

--- a/reference/src/layout/enums.md
+++ b/reference/src/layout/enums.md
@@ -321,10 +321,11 @@ as a niche.
 
 [`NonZeroU8`]: https://doc.rust-lang.org/std/num/struct.NonZeroU8.html
 
-The niche values of a type are parts of its validity invariant which, as of this
-writing, is the current active discussion topic in the unsafe code guidelines
-process. [rust-lang/rust#60300] specifies that the following types have at least
-one niche (the all-zeros bit-pattern):
+The niche values must be disjoint from the values allowed by the validity
+invariant. The validity invariant is, as of this writing, is the current active
+discussion topic in the unsafe code guidelines process. [rust-lang/rust#60300]
+specifies that the following types have at least one niche (the all-zeros
+bit-pattern):
 
 * `&T`
 * `&mut T`

--- a/reference/src/layout/enums.md
+++ b/reference/src/layout/enums.md
@@ -292,11 +292,15 @@ apply, as described below.
 
 #### Discriminant elision on Option-like enums
 
-(Meta-note: The content in this section is not described by any RFC
-and is therefore "non-normative".)
+(Meta-note: The content in this section is not fully described by any RFC and is
+therefore "non-normative". Parts of it were specified in
+[rust-lang/rust#60300].
 
-**Definition.** An **option-like enum** is a 2-variant enum where:
+[rust-lang/rust#60300]: https://github.com/rust-lang/rust/pull/60300
 
+**Definition.** An **option-like enum** is a 2-variant `enum` where:
+
+- the `enum` has no explicit `#[repr(...)]`, and
 - one variant has a single field, and
 - the other variant has no fields (the "unit variant").
 
@@ -313,12 +317,20 @@ values, which are called **niches**. For example, a value of type `&T`
 may never be `NULL`, and hence defines a niche consisting of the
 bitstring `0`.  Similarly, the standard library types [`NonZeroU8`]
 and friends may never be zero, and hence also define the value of `0`
-as a niche. (Types that define niche values will say so as part of the
-description of their validity invariant, which -- as of this writing
--- are the next topic up for discussion in the unsafe code guidelines
-process.)
+as a niche. 
 
 [`NonZeroU8`]: https://doc.rust-lang.org/std/num/struct.NonZeroU8.html
+
+The niche values of a type are parts of its validity invariant which, as of this
+writing, is the current active discussion topic in the unsafe code guidelines
+process. [rust-lang/rust#60300] specifies that the following types have a niche:
+
+* `&T`
+* `&mut T`
+* `extern "C" fn`
+* `core::num::NonZero*`
+* `core::ptr::NonNull<T>`
+* `#[repr(transparent)] struct` around one of the types in this list.
 
 **Option-like enums where the payload defines at least one niche value
 are guaranteed to be represented using the same memory layout as their
@@ -348,6 +360,17 @@ enum Enum1<T> {
   Present(T),
   Absent1,
   Absent2,
+}
+```
+
+**Example.** The following enum definition is **not** option-like,
+as it has an explicit `repr` attribute.
+
+```rust
+#[repr(u8)]
+enum Enum2<T> {
+  Present(T),
+  Absent1,
 }
 ```
 

--- a/reference/src/layout/enums.md
+++ b/reference/src/layout/enums.md
@@ -313,18 +313,18 @@ field which it contains; in the case of `Option<T>`, the payload has
 type `T`.
 
 **Definition.** In some cases, the payload type may contain illegal
-values, which are called **niches**. For example, a value of type `&T`
-may never be `NULL`, and hence defines a niche consisting of the
+values, which are called **[niches][niche]**. For example, a value of type `&T`
+may never be `NULL`, and hence defines a [niche] consisting of the
 bitstring `0`.  Similarly, the standard library types [`NonZeroU8`]
 and friends may never be zero, and hence also define the value of `0`
-as a niche. 
+as a [niche]. 
 
 [`NonZeroU8`]: https://doc.rust-lang.org/std/num/struct.NonZeroU8.html
 
-The niche values must be disjoint from the values allowed by the validity
+The [niche] values must be disjoint from the values allowed by the validity
 invariant. The validity invariant is, as of this writing, the current active
 discussion topic in the unsafe code guidelines process. [rust-lang/rust#60300]
-specifies that the following types have at least one niche (the all-zeros
+specifies that the following types have at least one [niche] (the all-zeros
 bit-pattern):
 
 * `&T`
@@ -334,15 +334,15 @@ bit-pattern):
 * `core::ptr::NonNull<T>`
 * `#[repr(transparent)] struct` around one of the types in this list.
 
-**Option-like enums where the payload defines at least one niche value
+**Option-like enums where the payload defines at least one [niche] value
 are guaranteed to be represented using the same memory layout as their
 payload.** This is called **discriminant elision**, as there is no
-explicit discriminant value stored anywhere. Instead, niche values are
+explicit discriminant value stored anywhere. Instead, [niche] values are
 used to represent the unit variant.
 
 The most common example is that `Option<&u8>` can be represented as an
 nullable `&u8` reference -- the `None` variant is then represented
-using the niche value zero. This is because a valid `&u8` value can
+using the [niche] value zero. This is because a valid `&u8` value can
 never be zero, so if we see a zero value, we know that this must be
 `None` variant.
 
@@ -375,6 +375,8 @@ enum Enum2<T> {
   Absent1,
 }
 ```
+
+[niche]: ../glossary.html#niche
 
 ## Unresolved questions
 


### PR DESCRIPTION
This PR updates the discriminant-elision optimization on option-like enums with the semantics specified in https://github.com/rust-lang/rust/pull/60300 

The main change is requiring that option-like enums do not have any explicit `#[repr(...)]` attributes.