### PR TITLE
Document that isize/usize are at least 16-bit wide on all platforms we currently support

### DIFF
--- a/reference/src/layout/scalars.md
+++ b/reference/src/layout/scalars.md
@@ -69,7 +69,11 @@ range of values that the pointer-holding integer types must support:
 * `intptr_t`: `[INTPTR_MIN, INTPTR_MAX] = [-(2^15 - 1), 2^15 - 1]` 
 * `uintptr_t`: `[0, UINTPTR_MAX] = [0, 2^16 - 1]`
 
-That is, `isize`/`usize` are at least 16-bit wide.
+That is, `isize`/`usize` are at least 16-bit wide. `libcore` relies on
+this guarantee and unconditionally provides:
+
+* `impl From<i16> for isize`,
+* `impl From<u16> for usize`.
 
 </details>
 

--- a/reference/src/layout/scalars.md
+++ b/reference/src/layout/scalars.md
@@ -37,11 +37,11 @@ The `isize` and `usize` types are pointer-sized signed and unsigned integers.
 They have the same layout as the [pointer types] for which the pointee is
 `Sized`, and are layout compatible with C's `uintptr_t` and `intptr_t` types.
 
-> **Note**: on all platforms that we currently support, `usize`/`isize` are at
-> least 16-bit wide. C99
-> [7.18.2.4](https://port70.net/~nsz/c/c99/n1256.html#7.18.2.4) requires
-> `uintptr_t` and `intptr_t` to be at least 16-bit wide. `libcore` relies on
-> this to unconditionally provide impls of `From<i16>`/`From<u16>` for
+> **Note**: C99 [7.18.2.4](https://port70.net/~nsz/c/c99/n1256.html#7.18.2.4)
+> requires `uintptr_t` and `intptr_t` to be at least 16-bit wide. That is, on
+> all platforms that we currently support, which have a C platform,
+> `isize`/`usize` are at least 16-bit wide. `libcore` relies on this guarantee
+> to unconditionally provide impls of `From<i16>`/`From<u16>` for
 > `isize`/`usize`.
 
 > **Note**: Rust's `usize` and C's `unsigned` types are **not** equivalent. C's

--- a/reference/src/layout/scalars.md
+++ b/reference/src/layout/scalars.md
@@ -35,8 +35,14 @@ of `char` is _implementation-defined_.
 
 The `isize` and `usize` types are pointer-sized signed and unsigned integers.
 They have the same layout as the [pointer types] for which the pointee is
-`Sized`, and are layout compatible with C's `uintptr_t` and `intptr_t` types,
-and are therefore at least 16-bit wide.
+`Sized`, and are layout compatible with C's `uintptr_t` and `intptr_t` types.
+
+> **Note**: on all platforms that we currently support, `usize`/`isize` are at
+> least 16-bit wide. C99
+> [7.18.2.4](https://port70.net/~nsz/c/c99/n1256.html#7.18.2.4) requires
+> `uintptr_t` and `intptr_t` to be at least 16-bit wide. `libcore` relies on
+> this to unconditionally provide impls of `From<i16>`/`From<u16>` for
+> `isize`/`usize`.
 
 > **Note**: Rust's `usize` and C's `unsigned` types are **not** equivalent. C's
 > `unsigned` is at least as large as a short, allowed to have padding bits, etc.
@@ -59,23 +65,6 @@ and are therefore at least 16-bit wide.
 >
 > These limits have not gone through the RFC process and are not guaranteed to
 > hold.
-
-<details><summary><b>Rationale</b></summary> 
-
-C99 [7.18.2.4](https://port70.net/~nsz/c/c99/n1256.html#7.18.2.4) "Limits of
-integer types capable of holding object pointers" provides the following minimum
-range of values that the pointer-holding integer types must support:
-
-* `intptr_t`: `[INTPTR_MIN, INTPTR_MAX] = [-(2^15 - 1), 2^15 - 1]` 
-* `uintptr_t`: `[0, UINTPTR_MAX] = [0, 2^16 - 1]`
-
-That is, `isize`/`usize` are at least 16-bit wide. `libcore` relies on
-this guarantee and unconditionally provides:
-
-* `impl From<i16> for isize`,
-* `impl From<u16> for usize`.
-
-</details>
 
 [pointer types]: ./pointers.md
 

--- a/reference/src/layout/scalars.md
+++ b/reference/src/layout/scalars.md
@@ -35,7 +35,8 @@ of `char` is _implementation-defined_.
 
 The `isize` and `usize` types are pointer-sized signed and unsigned integers.
 They have the same layout as the [pointer types] for which the pointee is
-`Sized`, and are layout compatible with C's `uintptr_t` and `intptr_t` types.
+`Sized`, and are layout compatible with C's `uintptr_t` and `intptr_t` types,
+and are therefore at least 16-bit wide.
 
 > **Note**: Rust's `usize` and C's `unsigned` types are **not** equivalent. C's
 > `unsigned` is at least as large as a short, allowed to have padding bits, etc.
@@ -58,6 +59,19 @@ They have the same layout as the [pointer types] for which the pointee is
 >
 > These limits have not gone through the RFC process and are not guaranteed to
 > hold.
+
+<details><summary><b>Rationale</b></summary> 
+
+C99 [7.18.2.4](https://port70.net/~nsz/c/c99/n1256.html#7.18.2.4) "Limits of
+integer types capable of holding object pointers" provides the following minimum
+range of values that the pointer-holding integer types must support:
+
+* `intptr_t`: `[INTPTR_MIN, INTPTR_MAX] = [-(2^15 - 1), 2^15 - 1]` 
+* `uintptr_t`: `[0, UINTPTR_MAX] = [0, 2^16 - 1]`
+
+That is, `isize`/`usize` are at least 16-bit wide.
+
+</details>
 
 [pointer types]: ./pointers.md
 

--- a/reference/src/layout/scalars.md
+++ b/reference/src/layout/scalars.md
@@ -40,9 +40,8 @@ They have the same layout as the [pointer types] for which the pointee is
 > **Note**: C99 [7.18.2.4](https://port70.net/~nsz/c/c99/n1256.html#7.18.2.4)
 > requires `uintptr_t` and `intptr_t` to be at least 16-bit wide. That is, on
 > all platforms that we currently support, which have a C platform,
-> `isize`/`usize` are at least 16-bit wide. `libcore` relies on this guarantee
-> to unconditionally provide impls of `From<i16>`/`From<u16>` for
-> `isize`/`usize`.
+> `isize`/`usize` are at least 16-bit wide. Currently, `libcore` unconditionally
+> provides impls of `From<i16>`/`From<u16>` for `isize`/`usize`.
 
 > **Note**: Rust's `usize` and C's `unsigned` types are **not** equivalent. C's
 > `unsigned` is at least as large as a short, allowed to have padding bits, etc.

--- a/reference/src/layout/scalars.md
+++ b/reference/src/layout/scalars.md
@@ -38,10 +38,9 @@ They have the same layout as the [pointer types] for which the pointee is
 `Sized`, and are layout compatible with C's `uintptr_t` and `intptr_t` types.
 
 > **Note**: C99 [7.18.2.4](https://port70.net/~nsz/c/c99/n1256.html#7.18.2.4)
-> requires `uintptr_t` and `intptr_t` to be at least 16-bit wide. That is, on
-> all platforms that we currently support, which have a C platform,
-> `isize`/`usize` are at least 16-bit wide. Currently, `libcore` unconditionally
-> provides impls of `From<i16>`/`From<u16>` for `isize`/`usize`.
+> requires `uintptr_t` and `intptr_t` to be at least 16-bit wide. All 
+> platforms we currently support have a C platform, and as a consequence,
+> `isize`/`usize` are at least 16-bit wide for all of them.
 
 > **Note**: Rust's `usize` and C's `unsigned` types are **not** equivalent. C's
 > `unsigned` is at least as large as a short, allowed to have padding bits, etc.


### PR DESCRIPTION
This is something that we already document, but was not explicitly spelled out.

cc @Gankro 