### PR TITLE
Resolve layout of single variant enums

### DIFF
--- a/reference/src/layout/enums.md
+++ b/reference/src/layout/enums.md
@@ -380,6 +380,8 @@ enum Enum2<T> {
 
 ### Layout of single variant enums
 
+> **NOTE**: the guarantees in this section have not been approved by an RFC process.
+
 **Single variant data-carrying*** enums without a `repr()` annotation have the
 same layout as the variant field. **Single variant fieldless** enums have the
 same layout as a unit struct.
@@ -419,6 +421,8 @@ the single-variant data-carrying enum `SingleVariantDataCarrying` has the same
 layout as `SomeStruct`.
 
 ### Layout of multi-variant enums with one inhabited variant
+
+> **NOTE**: the guarantees in this section have not been approved by an RFC process.
 
 The layout of **multi-variant** enums with **one inhabited variant** is the same
 as that of the single-variant enum containing that same inhabited variant.

--- a/reference/src/layout/enums.md
+++ b/reference/src/layout/enums.md
@@ -405,4 +405,4 @@ enum DataCarryingSingleVariant {
 
 See [Issue #79.](https://github.com/rust-rfcs/unsafe-code-guidelines/issues/79):
   
-* Layout of multi-variant enums with one inhabited variant.
+* Layout of multi-variant enums where only one variant is inhabited.

--- a/reference/src/layout/enums.md
+++ b/reference/src/layout/enums.md
@@ -46,10 +46,10 @@ As in C, discriminant values that are not specified are defined as
 either 0 (for the first variant) or as one more than the prior
 variant.
 
-**Data-carrying enums.** Enums whose variants have fields are called
-"data-carrying" enums. Note that for the purposes of this definition,
-it is not relevant whether those fields are zero-sized. Therefore this
-enum is considered "data-carrying":
+**Data-carrying enums.** Enums with at least one variant with fields are called
+"data-carrying" enums. Note that for the purposes of this definition, it is not
+relevant whether the variant fields are zero-sized. Therefore this enum is
+considered "data-carrying":
 
 ```rust
 enum Foo {

--- a/reference/src/layout/enums.md
+++ b/reference/src/layout/enums.md
@@ -378,47 +378,28 @@ enum Enum2<T> {
 
 [niche]: ../glossary.html#niche
 
-### Layout of single variant enums
+### Layout of enums with a single variant
 
 > **NOTE**: the guarantees in this section have not been approved by an RFC process.
 
-**Single variant data-carrying*** enums without a `repr()` annotation have the
-same layout as the variant field. **Single variant fieldless** enums have the
-same layout as a unit struct.
+**Data-carrying** enums with a single variant without a `repr()` annotation have
+the same layout as the variant field. **Fieldless** enums with a single variant
+have the same layout as a unit struct. 
 
-Here:
+For example, here:
 
 ```rust
-# use std::mem::{size_of, align_of};
 struct UnitStruct;
-enum SingleVariantFieldless { FieldlessVariant }
-# fn main() {
-assert_eq!(size_of::<SingleVariantFieldless>(), size_of::<UnitStruct>());
-assert_eq!(align_of::<SingleVariantFieldless>(), align_of::<UnitStruct>());
-// assert_eq!(call_abi_of::<SingleVariantFieldless>(), call_abi_of::<UnitStruct>());
-// assert_eq!(niches_of::<SingleVariantFieldless>(), niches_of::<UnitStruct>());
-# }
-```
+enum FieldlessSingleVariant { FieldlessVariant }
 
-the single-variant fieldless enum `SingleVariantFieldless` has the same layout
-as `UnitStruct`.
-
-Here: 
-
-```rust
-# use std::mem::{size_of, align_of};
 struct SomeStruct { x: u32 }
-enum SingleVariantDataCarrying {
+enum DataCarryingSingleVariant {
   DataCarryingVariant(SomeStruct),
 }
-# fn main() {
-# assert_eq!(size_of::<SingleVariantDataCarrying>(), size_of::<SomeStruct>());
-# assert_eq!(align_of::<SingleVariantDataCarrying>(), align_of::<SomeStruct>());
-# }
 ```
 
-the single-variant data-carrying enum `SingleVariantDataCarrying` has the same
-layout as `SomeStruct`.
+* `FieldSingleVariant` has the same layout as `UnitStruct`,
+* `DataCarryingSingleVariant` has the same layout as `SomeStruct`.
 
 ### Layout of multi-variant enums with one inhabited variant
 

--- a/reference/src/layout/enums.md
+++ b/reference/src/layout/enums.md
@@ -401,34 +401,8 @@ enum DataCarryingSingleVariant {
 * `FieldSingleVariant` has the same layout as `UnitStruct`,
 * `DataCarryingSingleVariant` has the same layout as `SomeStruct`.
 
-### Layout of multi-variant enums with one inhabited variant
+## Unresolved questions
 
-> **NOTE**: the guarantees in this section have not been approved by an RFC process.
-
-The layout of **multi-variant** enums with **one inhabited variant** is the same
-as that of the single-variant enum containing that same inhabited variant.
-
-Here:
-
-```rust
-# use std::mem::{size_of, align_of};
-struct SomeStruct { x: u32 }
-enum SingleVariantDataCarrying {
-    DataCarryingVariant(SomeStruct),
-}
-enum Void0 {}
-enum Void1 {}
-enum MultiVariantSingleHabited {
-  DataCarryingVariant(SomeStruct),
-  Uninhabited0(Void0),
-  Uninhabited1(Void1),
-}
-# fn main() {
-# use std::mem;
-# assert_eq!(size_of::<SingleVariantDataCarrying>(), size_of::<MultiVariantSingleHabited>());
-# assert_eq!(align_of::<SingleVariantDataCarrying>(), align_of::<MultiVariantSingleHabited>());
-# }
-```
-
-the `MultiVariantSingleHabited` enum has the same layout as
-`SingleVariantDataCarrying`.
+See [Issue #79.](https://github.com/rust-rfcs/unsafe-code-guidelines/issues/79):
+  
+* Layout of multi-variant enums with one inhabited variant.


### PR DESCRIPTION
Addresses part of #79. Addresses part of #37 .

I don't see any reasons not to guarantee this, and AFAICT nobody has mentioned any either.

---

EDIT: Note that this doesn't say anything about the layout of enums without variants, or where all variants are uninhabited. That should better be tackled in a different PR.