### PR TITLE
Guarantee the layout of some unions having a single non-zero-sized field

### DIFF
--- a/reference/src/glossary.md
+++ b/reference/src/glossary.md
@@ -171,6 +171,7 @@ Accordingly, we say that a library (or an individual function) is *sound* if it 
 Conversely, the library/function is *unsound* if safe code *can* cause Undefined Behavior.
 
 #### Layout
+[layout]: #layout
 
 The *layout* of a type defines its size and alignment as well as the offsets of its subobjects (e.g. fields of structs/unions/enum/... or elements of arrays).
 Moreover, the layout of a type records its *function call ABI* (or just *ABI* for short): how the type is passed *by value* across a function boundary.

--- a/reference/src/layout/unions.md
+++ b/reference/src/layout/unions.md
@@ -8,12 +8,12 @@ not to change until an RFC ratifies them.
 
 ### Layout of individual union fields
 
-When laying out an `union`, the compiler has to decide how the fields of the
-union are arranged. Union fields are laid out by the compiler "on top" of each
-other, that is, the bytes of one field might overlap with the bytes of another
-field - as opposed to, e.g., `struct`s, where the fields are laid out "next to"
-each other, such that the bytes of one field never overlap with the bytes of
-another field. This can be visualized as follows:
+The main degree of freedom the compiler has when computing the layout of a union
+is to determine the offset of the fields. Union fields are laid out by the
+compiler "on top" of each other, that is, the bytes of one field might overlap
+with the bytes of another field - as opposed to, e.g., `struct`s, where the
+fields are laid out "next to" each other, such that the bytes of one field never
+overlap with the bytes of another field. This can be visualized as follows:
 
 ```rust,ignore
 [ P P [field0_ty] P P P P ]

--- a/reference/src/layout/unions.md
+++ b/reference/src/layout/unions.md
@@ -57,7 +57,7 @@ you have to use `#[repr(C)]`.
 
 #### Layout of unions with a single non-zero-sized field
 
-The layout of unions with a single single non-[1-ZST]-field" is the same as the
+The layout of unions with a single non-[1-ZST]-field" is the same as the
 layout of that field if it has no [padding] bytes.
 
 For example, here:

--- a/reference/src/layout/unions.md
+++ b/reference/src/layout/unions.md
@@ -17,7 +17,6 @@ overlap. This can be visualized as follows:
 [ <----> [field1_ty] <--> ]
 [ <---> [field2_ty] <---> ]
 ```
-
 **Figure 1** (union-field layout): Each row in the picture shows the layout of
 the union for each of its variants. The `<-...->` and `[ ... ]` denote the
 differently-sized gaps and fields, respectively.

--- a/reference/src/layout/unions.md
+++ b/reference/src/layout/unions.md
@@ -18,10 +18,10 @@ overlap. This can be visualized as follows:
 [ <---> [field2_ty] <---> ]
 ```
 
-> **Figure: union field layout**: Each row in the picture shows the layout of
-> the union for each of its fields, where the square brackets `[]` depict an
-> array of bytes, `<-...->` denotes different amount of [padding], and
-> `[field{i}_ty]` is the bytes of the type of the `i`-th union field.
+**Figure 1** (union-field layout): Each row in the picture shows the layout of
+the union for each of its variants. The `<-...->` and `[ ... ]` denote the
+differently-sized gaps and fields, respectively and the `[field{i}_ty]` are the
+bytes of the type of the `i`-th union field.
 
 The individual fields (`[field{i}_ty_]`) are blocks of fixed size determined by
 the field's [layout]. The only degrees of freedom the compiler has when
@@ -59,11 +59,8 @@ you have to use `#[repr(C)]`.
 
 #### Layout of unions with a single non-zero-sized field
 
-The layout of unions with a single non-zero-sized field is the same as the
-layout of that field if:
-
-* all zero-sized fields are [1-ZST], and
-* the non-zero sized field has no padding bits.
+The layout of unions with a single single non-[1-ZST]-field" is the same as the
+layout of that field if it has no [padding] bytes.
 
 For example, here:
 

--- a/reference/src/layout/unions.md
+++ b/reference/src/layout/unions.md
@@ -12,7 +12,7 @@ A union consists of several variants, one for each field. All variants have the
 same size and start at the same memory address, such that in memory the variants
 overlap. This can be visualized as follows:
 
-```rust,ignore
+```text
 [ <--> [field0_ty] <----> ]
 [ <----> [field1_ty] <--> ]
 [ <---> [field2_ty] <---> ]
@@ -20,16 +20,19 @@ overlap. This can be visualized as follows:
 
 > **Figure: union field layout**: Each row in the picture shows the layout of
 > the union for each of its fields, where the square brackets `[]` depict an
-> array of bytes, `<-...->` denotes different amount of padding, and
+> array of bytes, `<-...->` denotes different amount of [padding], and
 > `[field{i}_ty]` is the bytes of the type of the `i`-th union field.
 
 The individual fields (`[field{i}_ty_]`) are blocks of fixed size determined by
-the field's layout. The only degrees of freedom the compiler has when computing
-the layout of a union are the size of the union, which can be larger than the
-size of its largest field, and the offset of each union field within its
-variant. How these are picked depends on certain constraints, lik for example,
-the alignment requirements of the fields, the `#[repr]` attribute of the
-`union`, etc.
+the field's [layout]. The only degrees of freedom the compiler has when
+computing the layout of a union are the size of the union, which can be larger
+than the size of its largest field, and the offset of each union field within
+its variant. How these are picked depends on certain constraints like, for
+example, the alignment requirements of the fields, the `#[repr]` attribute of
+the `union`, etc.
+
+[padding]: ../glossary.md#padding
+[layout]: ../glossary.md#layout
 
 ### Unions with default layout ("`repr(Rust)`")
 

--- a/reference/src/layout/unions.md
+++ b/reference/src/layout/unions.md
@@ -22,12 +22,12 @@ the union for each of its variants. The `<-...->` and `[ ... ]` denote the
 differently-sized gaps and fields, respectively.
 
 The individual fields (`[field{i}_ty_]`) are blocks of fixed size determined by
-the field's [layout]. The only degrees of freedom the compiler has when
-computing the layout of a union are the size of the union, which can be larger
-than the size of its largest field, and the offset of each union field within
-its variant. How these are picked depends on certain constraints like, for
-example, the alignment requirements of the fields, the `#[repr]` attribute of
-the `union`, etc.
+the field's [layout]. Since we allow creating references to union fields
+(`&u.i`), the only degrees of freedom the compiler has when computing the layout
+of a union are the size of the union, which can be larger than the size of its
+largest field, and the offset of each union field within its variant. How these
+are picked depends on certain constraints like, for example, the alignment
+requirements of the fields, the `#[repr]` attribute of the `union`, etc.
 
 [padding]: ../glossary.md#padding
 [layout]: ../glossary.md#layout
@@ -45,13 +45,13 @@ whether all fields have the same offset, etc.
 As of this writing, we want to keep the option of using non-zero offsets open
 for the future; whether this is useful depends on what exactly the
 compiler-assumed invariants about union contents are. This might become clearer
-after the validity of unions
-([unsafe-code-guidelines/73](https://github.com/rust-lang/unsafe-code-guidelines/issues/73))
-is settled.
+after the validity of unions [#73] is settled.
 
 Even if the offsets happen to be all 0, there might still be differences in the
 function call ABI.  If you need to pass unions by-value across an FFI boundary,
 you have to use `#[repr(C)]`.
+
+[#73]: https://github.com/rust-lang/unsafe-code-guidelines/issues/73
 
 </details>
 

--- a/reference/src/layout/unions.md
+++ b/reference/src/layout/unions.md
@@ -20,15 +20,15 @@ situated, i.e., the compiler picks the gap (often called padding) before and
 after each field. This can be visualized as follows:
 
 ```rust,ignore
-[ P P [field0_ty] P P P P ]
-[ P P P P [field1_ty] P P ]
-[ P P P [field2_ty] P P P ]
+[ <--> [field0_ty] <----> ]
+[ <----> [field1_ty] <--> ]
+[ <---> [field2_ty] <---> ]
 ```
 
 > **Figure: union field layout**: Each row in the picture shows the layout of
 > the union for each of its fields, where the square brackets `[]` depict an
-> array of bytes. Here, `P` is a byte of type `Pad` and `[field{i}_ty]` is the
-> bytes of the type of the `i`-th union field.
+> array of bytes, `<-...->` denotes different amount of padding, and
+> `[field{i}_ty]` is the bytes of the type of the `i`-th union field.
 
 The individual fields (`[field{i}_ty_]`) are blocks of fixed size determined by
 the field's layout. The compiler picks the offset of the fields with respect to

--- a/reference/src/layout/unions.md
+++ b/reference/src/layout/unions.md
@@ -8,12 +8,16 @@ not to change until an RFC ratifies them.
 
 ### Layout of individual union fields
 
-The main degree of freedom the compiler has when computing the layout of a union
-is to determine the offset of the fields. Union fields are laid out by the
-compiler "on top" of each other, that is, the bytes of one field might overlap
-with the bytes of another field - as opposed to, e.g., `struct`s, where the
-fields are laid out "next to" each other, such that the bytes of one field never
-overlap with the bytes of another field. This can be visualized as follows:
+A union consists of several variants, one for each field. These variants are
+laid out "on top" of each other, so they must all have the same size. That is,
+the byte of each variant overlaps with the byte located at the same offset in
+all other variants, and the bytes of one field might overlap with the bytes of
+another field - as opposed to, e.g., `struct`s, where the fields are laid out
+"next to" each other, such that the bytes of one field never overlap with the
+bytes of another field. The main degree of freedom the compiler has when
+computing the layout of a union is to pick where in its variant each field is
+situated, i.e., the compiler picks the gap (often called padding) before and
+after each field. This can be visualized as follows:
 
 ```rust,ignore
 [ P P [field0_ty] P P P P ]

--- a/reference/src/layout/unions.md
+++ b/reference/src/layout/unions.md
@@ -105,7 +105,7 @@ assert_eq!(align_of::<Zst2>(), 16);
 the layout of `U1` is **unspecified** because:
 
 * `Zst2` is not a [1-ZST], and
-* `SomeOtherStruct` has an unspecified layout and could contain padding bits.
+* `SomeOtherStruct` has an unspecified layout and could contain padding bytes.
 
 ### C-compatible layout ("repr C")
 

--- a/reference/src/layout/unions.md
+++ b/reference/src/layout/unions.md
@@ -25,10 +25,11 @@ overlap. This can be visualized as follows:
 
 The individual fields (`[field{i}_ty_]`) are blocks of fixed size determined by
 the field's layout. The only degrees of freedom the compiler has when computing
-the layout of a union are the size of the union and the offset of each union
-field within its variant. How these are picked depends on certain constraints,
-lik for example, the alignment requirements of the fields, the `#[repr]`
-attribute of the `union`, etc.
+the layout of a union are the size of the union, which can be larger than the
+size of its largest field, and the offset of each union field within its
+variant. How these are picked depends on certain constraints, lik for example,
+the alignment requirements of the fields, the `#[repr]` attribute of the
+`union`, etc.
 
 ### Unions with default layout ("`repr(Rust)`")
 

--- a/reference/src/layout/unions.md
+++ b/reference/src/layout/unions.md
@@ -34,10 +34,11 @@ the `union`, etc.
 
 ### Unions with default layout ("`repr(Rust)`")
 
-The default layout of Rust unions is **unspecified**. 
+Except for the guarantees provided below for some specific cases, the default
+layout of Rust unions is, _in general_, **unspecified**.
 
-That is, there are no guarantees about the offset of the fields, whether all
-fields have the same offset, etc.
+That is, there are no _general_ guarantees about the offset of the fields,
+whether all fields have the same offset, etc.
 
 <details><summary><b>Rationale</b></summary>
 
@@ -59,8 +60,8 @@ you have to use `#[repr(C)]`.
 The layout of unions with a single non-zero-sized field is the same as the
 layout of that field if:
 
-* that field has no padding bits, and
-* the alignment requirement of all zero-sized fields is 1.
+* all zero-sized fields are [1-ZST], and
+* the non-zero sized field has no padding bits.
 
 For example, here:
 
@@ -83,7 +84,7 @@ union U0 {
 
 the union `U0` has the same layout as `SomeStruct`, because `SomeStruct` has no
 padding bits - it is equivalent to an `i32` due to `repr(transparent)` - and
-because the alignment of `Zst` is 1.
+because `Zst` is a [1-ZST].
 
 On the other hand, here:
 
@@ -104,9 +105,10 @@ assert_eq!(align_of::<Zst2>(), 16);
 # }
 ```
 
-the alignment requirement of `Zst2` is not 1, and `SomeOtherStruct` has an
-unspecified layout and could contain padding bits. Therefore, the layout of `U1`
-is **unspecified**.
+the layout of `U1` is **unspecified** because:
+
+* `Zst2` is not a [1-ZST], and
+* `SomeOtherStruct` has an unspecified layout and could contain padding bits.
 
 ### C-compatible layout ("repr C")
 
@@ -172,3 +174,5 @@ with no fields. When such types are used as an union field in C++, a "naive"
 translation of that code into Rust will not produce a compatible result. Refer
 to the [struct chapter](structs-and-tuples.md#c-compatible-layout-repr-c) for
 further details.
+
+[1-ZST]: ../glossary.md#zero-sized-type--zst

--- a/reference/src/layout/unions.md
+++ b/reference/src/layout/unions.md
@@ -38,7 +38,7 @@ Except for the guarantees provided below for some specific cases, the default
 layout of Rust unions is, _in general_, **unspecified**.
 
 That is, there are no _general_ guarantees about the offset of the fields,
-whether all fields have the same offset, etc.
+whether all fields have the same offset, what the call ABI of the union is, etc.
 
 <details><summary><b>Rationale</b></summary>
 

--- a/reference/src/layout/unions.md
+++ b/reference/src/layout/unions.md
@@ -8,16 +8,9 @@ not to change until an RFC ratifies them.
 
 ### Layout of individual union fields
 
-A union consists of several variants, one for each field. These variants are
-laid out "on top" of each other, so they must all have the same size. That is,
-the byte of each variant overlaps with the byte located at the same offset in
-all other variants, and the bytes of one field might overlap with the bytes of
-another field - as opposed to, e.g., `struct`s, where the fields are laid out
-"next to" each other, such that the bytes of one field never overlap with the
-bytes of another field. The main degree of freedom the compiler has when
-computing the layout of a union is to pick where in its variant each field is
-situated, i.e., the compiler picks the gap (often called padding) before and
-after each field. This can be visualized as follows:
+A union consists of several variants, one for each field. All variants have the
+same size and start at the same memory address, such that in memory the variants
+overlap. This can be visualized as follows:
 
 ```rust,ignore
 [ <--> [field0_ty] <----> ]
@@ -31,10 +24,11 @@ after each field. This can be visualized as follows:
 > `[field{i}_ty]` is the bytes of the type of the `i`-th union field.
 
 The individual fields (`[field{i}_ty_]`) are blocks of fixed size determined by
-the field's layout. The compiler picks the offset of the fields with respect to
-the union and the `union` size according to certain constraints like, for
-example, the alignment requirements of the fields, the `#[repr]` attribute of
-the `union`, etc.
+the field's layout. The only degrees of freedom the compiler has when computing
+the layout of a union are the size of the union and the offset of each union
+field within its variant. How these are picked depends on certain constraints,
+lik for example, the alignment requirements of the fields, the `#[repr]`
+attribute of the `union`, etc.
 
 ### Unions with default layout ("`repr(Rust)`")
 

--- a/reference/src/layout/unions.md
+++ b/reference/src/layout/unions.md
@@ -20,8 +20,7 @@ overlap. This can be visualized as follows:
 
 **Figure 1** (union-field layout): Each row in the picture shows the layout of
 the union for each of its variants. The `<-...->` and `[ ... ]` denote the
-differently-sized gaps and fields, respectively and the `[field{i}_ty]` are the
-bytes of the type of the `i`-th union field.
+differently-sized gaps and fields, respectively.
 
 The individual fields (`[field{i}_ty_]`) are blocks of fixed size determined by
 the field's [layout]. The only degrees of freedom the compiler has when

--- a/reference/src/layout/unions.md
+++ b/reference/src/layout/unions.md
@@ -45,7 +45,7 @@ whether all fields have the same offset, etc.
 As of this writing, we want to keep the option of using non-zero offsets open
 for the future; whether this is useful depends on what exactly the
 compiler-assumed invariants about union contents are. This might become clearer
-after the validity of unions [#73] is settled.
+after the [validity of unions][#73] is settled.
 
 Even if the offsets happen to be all 0, there might still be differences in the
 function call ABI.  If you need to pass unions by-value across an FFI boundary,


### PR DESCRIPTION
This PR guarantees that unions having a single non-zero-sized field have the same layout as that field if:

* that field has no padding,
* all zero-sized fields have an alignment requirement of 1.

Without the requirement that the field might have no padding, the union would "inherit" the padding of their non-zero-sized field, such that these unions wouldn't be "bags of bits". 

We can relax this requirement later if we decide that unions shouldn't just be bags of bits, but for the time being, requiring no padding allows us to make this guarantee. 

Right now, we don't consider padding to be a part of layout. We should probably do so, since for unions padding doesn't really relate to field offsets - e.g., for repr(C) unions it results from the "overlapping" padding of their fields and trailing padding, see #160. 

An alternative way to word the no padding requirement here would be to guarantee this only for types with a "call ABI" equal to "Scalar" or "Vector", since those types have no padding. cc @eddyb  