### PR TITLE
Guarantee that some structs are zero sized

### DIFF
--- a/reference/src/layout/structs-and-tuples.md
+++ b/reference/src/layout/structs-and-tuples.md
@@ -124,10 +124,8 @@ x: u16, y: T }` where `T = u32` are not guaranteed to be identical.
 
 #### Zero-sized structs
 
-Structs with default layout (`repr(Rust)`), layout with increased alignment
-(`repr(align(N))`), packed layout (`repr(packed(N))`), or C-compatible layout
-(`repr(C)`) are zero-sized, if they contain no fields of non-zero size. That is,
-either the type has no fields, or all of its fields have zero size.
+For `repr(Rust)`, `repr(packed(N))`, `repr(align(N))`, and `repr(C)`
+structs: if all fields of a struct have size 0, then the struct has size 0.
 
 For example, all these types are zero-sized:
 

--- a/reference/src/layout/structs-and-tuples.md
+++ b/reference/src/layout/structs-and-tuples.md
@@ -128,6 +128,20 @@ Structs with default layout are zero-sized, if they contain no fields of
 non-zero size. That is, either the type has no fields, or all of its fields have
 zero size.
 
+For example, all these types are zero-sized:
+
+```rust
+# use std::mem::size_of;
+struct Zst0;
+struct Zst1(Zst0);
+struct Zst2(Zst1, Zst0);
+# fn main() {
+# assert_eq!(size_of::<Zst0>(), 0);
+# assert_eq!(size_of::<Zst1>(), 0);
+# assert_eq!(size_of::<Zst2>(), 0);
+# }
+```
+
 #### Unresolved questions
 
 During the course of the discussion in [#11] and [#12], various

--- a/reference/src/layout/structs-and-tuples.md
+++ b/reference/src/layout/structs-and-tuples.md
@@ -124,16 +124,17 @@ x: u16, y: T }` where `T = u32` are not guaranteed to be identical.
 
 #### Zero-sized structs
 
-Structs with default layout or default layout with increased alignment are
-zero-sized, if they contain no fields of non-zero size. That is, either the type
-has no fields, or all of its fields have zero size.
+Structs with default layout (`repr(Rust)`), layout with increased alignment
+(`repr(align(N))`), packed layout (`repr(packed(N))`), or C-compatible layout
+(`repr(C)`) are zero-sized, if they contain no fields of non-zero size. That is,
+either the type has no fields, or all of its fields have zero size.
 
 For example, all these types are zero-sized:
 
 ```rust
 # use std::mem::size_of;
 #[repr(align(32))] struct Zst0;
-struct Zst1(Zst0);
+#[repr(C)] struct Zst1(Zst0);
 struct Zst2(Zst1, Zst0);
 # fn main() {
 # assert_eq!(size_of::<Zst0>(), 0);

--- a/reference/src/layout/structs-and-tuples.md
+++ b/reference/src/layout/structs-and-tuples.md
@@ -124,15 +124,15 @@ x: u16, y: T }` where `T = u32` are not guaranteed to be identical.
 
 #### Zero-sized structs
 
-Structs with default layout are zero-sized, if they contain no fields of
-non-zero size. That is, either the type has no fields, or all of its fields have
-zero size.
+Structs with default layout or default layout with increased alignment are
+zero-sized, if they contain no fields of non-zero size. That is, either the type
+has no fields, or all of its fields have zero size.
 
 For example, all these types are zero-sized:
 
 ```rust
 # use std::mem::size_of;
-struct Zst0;
+#[repr(align(32))] struct Zst0;
 struct Zst1(Zst0);
 struct Zst2(Zst1, Zst0);
 # fn main() {

--- a/reference/src/layout/structs-and-tuples.md
+++ b/reference/src/layout/structs-and-tuples.md
@@ -122,6 +122,12 @@ compiler will not reorder it, to allow for the possibility of
 unsizing. E.g., `struct Foo { x: u16, y: u32 }` and `struct Foo<T> {
 x: u16, y: T }` where `T = u32` are not guaranteed to be identical.
 
+#### Zero-sized structs
+
+Structs with default layout are zero-sized, if they contain no fields of
+non-zero size. That is, either the type has no fields, or all of its fields have
+zero size.
+
 #### Unresolved questions
 
 During the course of the discussion in [#11] and [#12], various
@@ -130,15 +136,6 @@ are currently considering **unresolved** and -- for each of them -- an
 issue has been opened for further discussion on the repository. This
 section documents the questions and gives a few light details, but the
 reader is referred to the issues for further discussion.
-
-**Zero-sized structs ([#37]).** If you have a struct which --
-transitively -- contains no data of non-zero size, then the size of
-that struct will be zero as well. These zero-sized structs appear
-frequently as exceptions in other layout considerations (e.g.,
-single-field structs). An example of such a struct is
-`std::marker::PhantomData`.
-
-[#37]: https://github.com/rust-rfcs/unsafe-code-guidelines/issues/37
 
 **Single-field structs ([#34]).** If you have a struct with single field
 (`struct Foo { x: T }`), should we guarantee that the memory layout of


### PR DESCRIPTION
This addresses part of #37, by guaranteeing that structs have zero size if they don't contain any non-zero-sized field.