### PR TITLE
Guarantee the layout of structs with a single non-zero-sized field

### DIFF
--- a/reference/src/layout/structs-and-tuples.md
+++ b/reference/src/layout/structs-and-tuples.md
@@ -141,10 +141,10 @@ struct Zst2(Zst1, Zst0);
 # }
 ```
 
-#### Default layout of structs with a single non-zero-sized field
+#### Default layout of structs where only a single field is not a 1-ZST
 
-The default layout of structs with a single non-zero-sized field is the same as
-the layout of that field if all other fields are [1-ZST]
+The default layout of structs where only a single field is not a 1-ZST is the
+same as the layout of that non-1-ZST field.
 
 For example, the layout of:
 

--- a/reference/src/layout/structs-and-tuples.md
+++ b/reference/src/layout/structs-and-tuples.md
@@ -146,8 +146,10 @@ struct S3(Zst1); // same layout as Zst1
 
 #### Zero-sized structs
 
-For `repr(Rust)`, `repr(packed(N))`, `repr(align(N))`, and `repr(C)`
-structs: if all fields of a struct have size 0, then the struct has size 0.
+For `repr(Rust)`, `repr(packed(N))`, `repr(align(N))`, and `repr(C)` structs: if
+all fields of a struct have size 0, then the struct has size 0. In particular, a
+struct with no fields is a ZST, and if it has no repr attribute it is moreover a
+1-ZST as it also has no alignment requirements.
 
 For example, all these types are zero-sized:
 

--- a/reference/src/layout/structs-and-tuples.md
+++ b/reference/src/layout/structs-and-tuples.md
@@ -122,6 +122,7 @@ compiler will not reorder it, to allow for the possibility of
 unsizing. E.g., `struct Foo { x: u16, y: u32 }` and `struct Foo<T> {
 x: u16, y: T }` where `T = u32` are not guaranteed to be identical.
 
+<<<<<<< HEAD
 #### Zero-sized structs
 
 For `repr(Rust)`, `repr(packed(N))`, `repr(align(N))`, and `repr(C)`
@@ -141,6 +142,28 @@ struct Zst2(Zst1, Zst0);
 # }
 ```
 
+=======
+#### Default layout of structs with a single non-zero-sized field
+
+The default layout of structs with a single non-zero-sized field is the same as
+the layout of that field if the alignment requirement of all other fields is 1.
+
+For example, the layout of:
+
+```rust
+struct SomeStruct(i32, ());
+```
+
+is the same as the layout of `i32`, but the layout of:
+
+```rust
+#[repr(align(16))] struct Zst;
+struct SomeOtherStruct(i32, Zst);
+```
+
+is **unspecified**, since there is a zero-sized field in `SomeOtherStruct` with
+alignment greater than 1.
+
 #### Unresolved questions
 
 During the course of the discussion in [#11] and [#12], various
@@ -150,14 +173,14 @@ issue has been opened for further discussion on the repository. This
 section documents the questions and gives a few light details, but the
 reader is referred to the issues for further discussion.
 
-**Single-field structs ([#34]).** If you have a struct with single field
-(`struct Foo { x: T }`), should we guarantee that the memory layout of
-`Foo` is identical to the memory layout of `T` (note that ABI details
-around function calls may still draw a distinction, which is why
-`#[repr(transparent)]` is needed). What about zero-sized types like
-`PhantomData`?
+**Zero-sized structs ([#37]).** If you have a struct which --
+transitively -- contains no data of non-zero size, then the size of
+that struct will be zero as well. These zero-sized structs appear
+frequently as exceptions in other layout considerations (e.g.,
+single-field structs). An example of such a struct is
+`std::marker::PhantomData`.
 
-[#34]: https://github.com/rust-rfcs/unsafe-code-guidelines/issues/34
+[#37]: https://github.com/rust-rfcs/unsafe-code-guidelines/issues/37
 
 **Homogeneous structs ([#36]).** If you have homogeneous structs, where all
 the `N` fields are of a single type `T`, can we guarantee a mapping to

--- a/reference/src/layout/structs-and-tuples.md
+++ b/reference/src/layout/structs-and-tuples.md
@@ -124,10 +124,6 @@ compiler will not reorder it, to allow for the possibility of
 unsizing. E.g., `struct Foo { x: u16, y: u32 }` and `struct Foo<T> {
 x: u16, y: T }` where `T = u32` are not guaranteed to be identical.
 
-#### Structs with no fields
-
-Structs with default layout and no fields are [1-ZST].
-
 #### Structs with 1-ZST fields
 
 For the purposes of struct layout [1-ZST] fields are ignored.

--- a/reference/src/layout/structs-and-tuples.md
+++ b/reference/src/layout/structs-and-tuples.md
@@ -122,7 +122,6 @@ compiler will not reorder it, to allow for the possibility of
 unsizing. E.g., `struct Foo { x: u16, y: u32 }` and `struct Foo<T> {
 x: u16, y: T }` where `T = u32` are not guaranteed to be identical.
 
-<<<<<<< HEAD
 #### Zero-sized structs
 
 For `repr(Rust)`, `repr(packed(N))`, `repr(align(N))`, and `repr(C)`
@@ -142,11 +141,10 @@ struct Zst2(Zst1, Zst0);
 # }
 ```
 
-=======
 #### Default layout of structs with a single non-zero-sized field
 
 The default layout of structs with a single non-zero-sized field is the same as
-the layout of that field if the alignment requirement of all other fields is 1.
+the layout of that field if all other fields are [1-ZST]
 
 For example, the layout of:
 
@@ -160,9 +158,7 @@ is the same as the layout of `i32`, but the layout of:
 #[repr(align(16))] struct Zst;
 struct SomeOtherStruct(i32, Zst);
 ```
-
-is **unspecified**, since there is a zero-sized field in `SomeOtherStruct` with
-alignment greater than 1.
+is **unspecified**, since `Zst` is not a [1-ZST].
 
 #### Unresolved questions
 
@@ -423,3 +419,5 @@ proposal (and -- further -- it does not match our existing behavior):
   thread](https://github.com/rust-rfcs/unsafe-code-guidelines/pull/31#discussion_r224955817)).
 - Many people would prefer the name ordering to be chosen for
   "readability" and not optimal layout.
+
+[1-ZST]: ../glossary.md#zero-sized-type--zst

--- a/reference/src/layout/structs-and-tuples.md
+++ b/reference/src/layout/structs-and-tuples.md
@@ -141,24 +141,21 @@ struct Zst2(Zst1, Zst0);
 # }
 ```
 
-#### Default layout of structs where only a single field is not a 1-ZST
+#### Structs with 1-ZST fields
 
-The default layout of structs where only a single field is not a 1-ZST is the
-same as the layout of that non-1-ZST field.
+For the purposes of struct layout [1-ZST] fields are ignored.
 
-For example, the layout of:
-
-```rust
-struct SomeStruct(i32, ());
-```
-
-is the same as the layout of `i32`, but the layout of:
+For example, 
 
 ```rust
-#[repr(align(16))] struct Zst;
-struct SomeOtherStruct(i32, Zst);
+type Zst1 = ();
+struct S1(i32, Zst1);
+
+type Zst2 = [u16; 0];
+struct S2(Zst2, Zst1);
 ```
-is **unspecified**, since `Zst` is not a [1-ZST].
+
+the layout of `S1` is the same as that of `i32` and the layout of `S2` as that of `Zst2`. 
 
 #### Unresolved questions
 
@@ -168,15 +165,6 @@ are currently considering **unresolved** and -- for each of them -- an
 issue has been opened for further discussion on the repository. This
 section documents the questions and gives a few light details, but the
 reader is referred to the issues for further discussion.
-
-**Zero-sized structs ([#37]).** If you have a struct which --
-transitively -- contains no data of non-zero size, then the size of
-that struct will be zero as well. These zero-sized structs appear
-frequently as exceptions in other layout considerations (e.g.,
-single-field structs). An example of such a struct is
-`std::marker::PhantomData`.
-
-[#37]: https://github.com/rust-rfcs/unsafe-code-guidelines/issues/37
 
 **Homogeneous structs ([#36]).** If you have homogeneous structs, where all
 the `N` fields are of a single type `T`, can we guarantee a mapping to

--- a/reference/src/layout/structs-and-tuples.md
+++ b/reference/src/layout/structs-and-tuples.md
@@ -84,15 +84,17 @@ Structs can have various `#[repr]` flags that influence their layout:
 
 ### Default layout ("repr rust")
 
-**The default layout of structs is not specified.** As of this
-writing, we have not reached a full consensus on what limitations
-should exist on possible field struct layouts, so effectively one must
-assume that the compiler can select any layout it likes for each
-struct on each compilation, and it is not required to select the same
-layout across two compilations. This implies that (among other things)
-two structs with the same field types may not be laid out in the same
-way (for example, the hypothetical struct representing tuples may be
-laid out differently from user-declared structs).
+With the exception of the guarantees provided below, **the default layout of
+structs is not specified.** 
+
+As of this writing, we have not reached a full consensus on what limitations
+should exist on possible field struct layouts, so effectively one must assume
+that the compiler can select any layout it likes for each struct on each
+compilation, and it is not required to select the same layout across two
+compilations. This implies that (among other things) two structs with the same
+field types may not be laid out in the same way (for example, the hypothetical
+struct representing tuples may be laid out differently from user-declared
+structs).
 
 Known things that can influence layout (non-exhaustive):
 
@@ -122,6 +124,26 @@ compiler will not reorder it, to allow for the possibility of
 unsizing. E.g., `struct Foo { x: u16, y: u32 }` and `struct Foo<T> {
 x: u16, y: T }` where `T = u32` are not guaranteed to be identical.
 
+#### Structs with no fields
+
+Structs with default layout and no fields are [1-ZST].
+
+#### Structs with 1-ZST fields
+
+For the purposes of struct layout [1-ZST] fields are ignored.
+
+For example:
+
+```rust
+type Zst1 = ();
+struct S1(i32, Zst1); // same layout as i32
+
+type Zst2 = [u16; 0];
+struct S2(Zst2, Zst1); // same layout as Zst2
+
+struct S3(Zst1); // same layout as Zst1
+```
+
 #### Zero-sized structs
 
 For `repr(Rust)`, `repr(packed(N))`, `repr(align(N))`, and `repr(C)`
@@ -140,22 +162,6 @@ struct Zst2(Zst1, Zst0);
 # assert_eq!(size_of::<Zst2>(), 0);
 # }
 ```
-
-#### Structs with 1-ZST fields
-
-For the purposes of struct layout [1-ZST] fields are ignored.
-
-For example, 
-
-```rust
-type Zst1 = ();
-struct S1(i32, Zst1);
-
-type Zst2 = [u16; 0];
-struct S2(Zst2, Zst1);
-```
-
-the layout of `S1` is the same as that of `i32` and the layout of `S2` as that of `Zst2`. 
 
 #### Unresolved questions
 


### PR DESCRIPTION
This PR guarantees the layout of structs with a single non-zero-sized field to be the same layout as that of that field if the alignment requirements of all other fields is 1.

Closes #34 .