### PR TITLE
Initial Glossary entry for Aliasing

### DIFF
--- a/reference/src/glossary.md
+++ b/reference/src/glossary.md
@@ -14,7 +14,7 @@ If data immediately pointed to by a `*const T` or `&*const T` is mutated, that's
 *Interior mutability* refers to the ability to perform interior mutation without causing UB.
 All interior mutation in Rust has to happen inside an [`UnsafeCell`](https://doc.rust-lang.org/core/cell/struct.UnsafeCell.html), so all data structures that have interior mutability must (directly or indirectly) use `UnsafeCell` for this purpose.
 
-#### Validity and safety invariant
+#### Validity Invariant
 
 The *validity invariant* is an invariant that all data must uphold any time it is accessed or copied in a typed manner.
 This invariant is known to the compiler and exploited by optimizations such as improved enum layout or eliding in-bounds checks.
@@ -30,6 +30,8 @@ fn main() { unsafe {
   let t: T = std::mem::transmute(TERM);
 } }
 ```
+
+#### Safety Invariant
 
 The *safety* invariant is an invariant that safe code may assume all data to uphold.
 This invariant is used to justify which operations safe code can perform.

--- a/reference/src/glossary.md
+++ b/reference/src/glossary.md
@@ -23,8 +23,8 @@ fn main() {
 }
 ```
 
-In this case, both `r` and `s` alias each other, since they both point to the
-memory of `u`.
+In this case, both `r` and `s` alias each other, since they both point to all of
+the bytes of `u`.
 
 However, `head` and `tail` do not alias each other: `head` points to the first
 byte of `u` and `tail` points to the other seven bytes of `u` after it.

--- a/reference/src/glossary.md
+++ b/reference/src/glossary.md
@@ -3,7 +3,7 @@
 #### Aliasing
 
 (Please note: a full aliasing model for Rust has not yet been constructed, but
-at the moment we can give the following guidelines.)
+at the moment we can give the following definition.)
 
 *Aliasing* is any time one pointer or reference points to a "span" of memory
 that overlaps with the span of another pointer or reference. A span of memory is

--- a/reference/src/glossary.md
+++ b/reference/src/glossary.md
@@ -3,7 +3,9 @@
 #### Aliasing
 
 (Please note: a full aliasing model for Rust has not yet been constructed, but
-at the moment we can give the following definition.)
+at the moment we can give the following definition. The most developed potential
+aliasing model so far is known as "Stacked Borrows", and can be found
+[here](https://github.com/Lokathor/unsafe-code-guidelines/blob/lokathor/wip/stacked-borrows.md).)
 
 *Aliasing* is any time one pointer or reference points to a "span" of memory
 that overlaps with the span of another pointer or reference. A span of memory is

--- a/reference/src/glossary.md
+++ b/reference/src/glossary.md
@@ -5,7 +5,7 @@
 (Please note: a full aliasing model for Rust has not yet been constructed, but
 at the moment we can give the following definition. The most developed potential
 aliasing model so far is known as "Stacked Borrows", and can be found
-[here](https://github.com/Lokathor/unsafe-code-guidelines/blob/lokathor/wip/stacked-borrows.md).)
+[here](https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md).)
 
 *Aliasing* is any time one pointer or reference points to a "span" of memory
 that overlaps with the span of another pointer or reference. A span of memory is

--- a/reference/src/glossary.md
+++ b/reference/src/glossary.md
@@ -14,22 +14,13 @@ If data immediately pointed to by a `*const T` or `&*const T` is mutated, that's
 *Interior mutability* refers to the ability to perform interior mutation without causing UB.
 All interior mutation in Rust has to happen inside an [`UnsafeCell`](https://doc.rust-lang.org/core/cell/struct.UnsafeCell.html), so all data structures that have interior mutability must (directly or indirectly) use `UnsafeCell` for this purpose.
 
-#### Validity Invariant
+#### Layout
 
-The *validity invariant* is an invariant that all data must uphold any time it is accessed or copied in a typed manner.
-This invariant is known to the compiler and exploited by optimizations such as improved enum layout or eliding in-bounds checks.
+The *layout* of a type defines its size and alignment as well as the offsets of its subobjects (e.g. fields of structs/unions/enum/... or elements of arrays).
+Moreover, the layout of a type records its *function call ABI* (or just *ABI* for short): how the type is passed *by value* across a function boundary.
 
-In terms of MIR statements, "accessed or copied" means whenever an assignment statement is executed.
-That statement has a type (LHS and RHS must have the same type), and the data being assigned must be valid at that type.
-Moreover, arguments passed to a function must be valid at the type given in the callee signature, and the return value of a function must be valid at the type given in the caller signature.
-OPEN QUESTION: Are there more cases where data must be valid?
-
-In terms of code, some data computed by `TERM` is valid at type `T` if and only if the following program does not have UB:
-```rust,ignore
-fn main() { unsafe {
-  let t: T = std::mem::transmute(TERM);
-} }
-```
+Note: Originally, *layout* and *representation* were treated as synonyms, and Rust language features like the `#[repr]` attribute reflect this. 
+In this document, *layout* and *representation* are not synonyms.
 
 #### Safety Invariant
 
@@ -53,14 +44,6 @@ Moreover, such unsafe code must not return a non-UTF-8 string to the "outside" o
 To summarize: *Data must always be valid, but it only must be safe in safe code.*
 For some more information, see [this blog post](https://www.ralfj.de/blog/2018/08/22/two-kinds-of-invariants.html).
 
-#### Layout
-
-The *layout* of a type defines its size and alignment as well as the offsets of its subobjects (e.g. fields of structs/unions/enum/... or elements of arrays).
-Moreover, the layout of a type records its *function call ABI* (or just *ABI* for short): how the type is passed *by value* across a function boundary.
-
-Note: Originally, *layout* and *representation* were treated as synonyms, and Rust language features like the `#[repr]` attribute reflect this. 
-In this document, *layout* and *representation* are not synonyms.
-
 #### Niche
 
 The *niche* of a type determines invalid bit-patterns that will be used by layout optimizations.
@@ -75,6 +58,22 @@ niches. For example, the "all bits uninitialized" is an invalid bit-pattern for
 `&mut T`, but this bit-pattern cannot be used by layout optimizations, and is not a
 niche.
 
+#### Validity Invariant
+
+The *validity invariant* is an invariant that all data must uphold any time it is accessed or copied in a typed manner.
+This invariant is known to the compiler and exploited by optimizations such as improved enum layout or eliding in-bounds checks.
+
+In terms of MIR statements, "accessed or copied" means whenever an assignment statement is executed.
+That statement has a type (LHS and RHS must have the same type), and the data being assigned must be valid at that type.
+Moreover, arguments passed to a function must be valid at the type given in the callee signature, and the return value of a function must be valid at the type given in the caller signature.
+OPEN QUESTION: Are there more cases where data must be valid?
+
+In terms of code, some data computed by `TERM` is valid at type `T` if and only if the following program does not have UB:
+```rust,ignore
+fn main() { unsafe {
+  let t: T = std::mem::transmute(TERM);
+} }
+```
 
 ### TODO
 

--- a/reference/src/glossary.md
+++ b/reference/src/glossary.md
@@ -1,5 +1,42 @@
 ## Glossary
 
+#### Aliasing
+
+(Please note: a full aliasing model for Rust has not yet been constructed, but
+at the moment we can give the following guidelines.)
+
+*Aliasing* is any time two pointers and/or references point to the same "span"
+of memory. A span of memory is similar to how a slice works: there's a base byte
+address as well as a length in bytes.
+
+Consider the following example:
+
+```rust
+fn main() {
+    let u: u64 = 7_u64;
+    let r: &u64 = &u;
+    let s: &[u8] = unsafe {
+        core::slice::from_raw_parts(&u as *const u64 as *const u8, 8)
+    };
+    let (head, tail) = s.split_first().unwrap();
+}
+```
+
+In this case, both `r` and `s` alias each other, since they both point to the
+memory of `u`.
+
+However, `head` and `tail` do not alias each other: `head` points to the first
+byte of `u` and `tail` points to the other seven bytes of `u` after it.
+
+* The span length of `&T`, `&mut T`, `*const T`, or `*mut T` when `T` is
+  [`Sized`](https://doc.rust-lang.org/core/marker/trait.Sized.html) is
+  `size_of<T>()`.
+* When `T` is not `Sized` the span length is `size_of_val(t)`.
+
+One interesting side effect of these rules is that references and pointers to
+Zero Sized Types _never_ alias each other, because their span length is always 0
+bytes.
+
 #### Interior mutability
 
 *Interior Mutation* means mutating memory where there also exists a live shared reference pointing to the same memory; or mutating memory through a pointer derived from a shared reference.

--- a/reference/src/glossary.md
+++ b/reference/src/glossary.md
@@ -27,7 +27,8 @@ In this case, both `r` and `s` alias each other, since they both point to all of
 the bytes of `u`.
 
 However, `head` and `tail` do not alias each other: `head` points to the first
-byte of `u` and `tail` points to the other seven bytes of `u` after it.
+byte of `u` and `tail` points to the other seven bytes of `u` after it. Also,
+both `head` and `tail` alias `s`.
 
 * The span length of `&T`, `&mut T`, `*const T`, or `*mut T` when `T` is
   [`Sized`](https://doc.rust-lang.org/core/marker/trait.Sized.html) is

--- a/reference/src/glossary.md
+++ b/reference/src/glossary.md
@@ -32,7 +32,10 @@ However, `head` and `tail` do not alias each other: `head` points to the first
 byte of `u` and `tail` points to the other seven bytes of `u` after it. Both `head`
 and `tail` alias `s`, any overlap is sufficient to count as an alias.
 
-* The span of a pointer or reference is the size of the value being pointed to or referenced.
+The span of a pointer or reference is the size of the value being pointed to or referenced.
+
+Depending on the type, you can determine the size as follows:
+
 * For a type `T` that is [`Sized`](https://doc.rust-lang.org/core/marker/trait.Sized.html)
   The span length of a pointer or reference to `T` is found with `size_of::<T>()`.
 * When `T` is not `Sized` the story is a little tricker:
@@ -41,7 +44,8 @@ and `tail` alias `s`, any overlap is sufficient to count as an alias.
   * If you have a pointer `p` you must unsafely convert that to a reference before
     you can use `size_of_val`. There is not currently a safe way to determine the
     span of a pointer to an unsized type.
-* The Data Layout chapter also has more information on the sizes of different types.
+
+The Data Layout chapter also has more information on the sizes of different types.
 
 One interesting side effect of these rules is that references and pointers to
 Zero Sized Types _never_ alias each other, because their span length is always 0

--- a/reference/src/glossary.md
+++ b/reference/src/glossary.md
@@ -27,13 +27,19 @@ In this case, both `r` and `s` alias each other, since they both point to all of
 the bytes of `u`.
 
 However, `head` and `tail` do not alias each other: `head` points to the first
-byte of `u` and `tail` points to the other seven bytes of `u` after it. Also,
-both `head` and `tail` alias `s`.
+byte of `u` and `tail` points to the other seven bytes of `u` after it. Both `head`
+and `tail` alias `s`, any overlap is sufficient to count as an alias.
 
-* The span length of `&T`, `&mut T`, `*const T`, or `*mut T` when `T` is
-  [`Sized`](https://doc.rust-lang.org/core/marker/trait.Sized.html) is
-  `size_of<T>()`.
-* When `T` is not `Sized` the span length is `size_of_val(t)`.
+* The span of a pointer or reference is the size of the value being pointed to or referenced.
+* For some type `T` that is [`Sized`](https://doc.rust-lang.org/core/marker/trait.Sized.html)
+  The span length of a pointer or reference to `T` is found with `size_of::<T>()`.
+* When `T` is not `Sized` the story is a little tricker:
+  * If you have a reference `r` you can use `size_of_val(r)` to determine the
+    span of the reference.
+  * If you have a pointer `p` you must unsafely convert that to a reference before
+    you can use `size_of_val`. There is not currently a safe way to determine the
+    span of a pointer to an unsized type.
+* The Data Layout chapter also has more information on the sizes of different types.
 
 One interesting side effect of these rules is that references and pointers to
 Zero Sized Types _never_ alias each other, because their span length is always 0

--- a/reference/src/glossary.md
+++ b/reference/src/glossary.md
@@ -38,6 +38,11 @@ One interesting side effect of these rules is that references and pointers to
 Zero Sized Types _never_ alias each other, because their span length is always 0
 bytes.
 
+It is also important to know that LLVM IR has a `noalias` attribute that works
+somewhat differently from this definition. However, that's considered a low
+level detail of a particular Rust implementation. When programming Rust, the
+Abstract Rust Machine is intended to operate according to the definition here.
+
 #### Interior mutability
 
 *Interior Mutation* means mutating memory where there also exists a live shared reference pointing to the same memory; or mutating memory through a pointer derived from a shared reference.

--- a/reference/src/glossary.md
+++ b/reference/src/glossary.md
@@ -45,7 +45,7 @@ Depending on the type, you can determine the size as follows:
     you can use `size_of_val`. There is not currently a safe way to determine the
     span of a pointer to an unsized type.
 
-The Data Layout chapter also has more information on the sizes of different types.
+The [Data layout](./layout.md) chapter also has more information on the sizes of different types.
 
 One interesting side effect of these rules is that references and pointers to
 Zero Sized Types _never_ alias each other, because their span length is always 0

--- a/reference/src/glossary.md
+++ b/reference/src/glossary.md
@@ -5,9 +5,10 @@
 (Please note: a full aliasing model for Rust has not yet been constructed, but
 at the moment we can give the following guidelines.)
 
-*Aliasing* is any time two pointers and/or references point to the same "span"
-of memory. A span of memory is similar to how a slice works: there's a base byte
-address as well as a length in bytes.
+*Aliasing* is any time one pointer or reference points to a "span" of memory
+that overlaps with the span of another pointer or reference. A span of memory is
+similar to how a slice works: there's a base byte address as well as a length in
+bytes.
 
 Consider the following example:
 


### PR DESCRIPTION
This is basically the same definition as the Rustonomicon has, but now we're re-stating it here with (I hope) improved clarity.

Of note, it's now written down somewhere visible that ZSTs never alias.

Also I made the whole Glossary alphabetical.

Note: This is not intended to be new guarantees at all, I don't think I wrote anything that can be taken that way, it's just a definition so that people can speak with common terms.