### PR TITLE
update for no longer recursing below enums

### DIFF
--- a/wip/stacked-borrows.md
+++ b/wip/stacked-borrows.md
@@ -286,6 +286,11 @@ The interesting question is which permission to use for the new item:
 - For mutable raw pointers and two-phase `Unique`, the permission is `SharedReadWrite`.
 - For `Shared`, the permission is different for locations inside of and outside of `UnsafeCell`.
   Inside `UnsafeCell`, it is `SharedReadWrite`; outside it is `SharedReadOnly`.
+  - The `UnsafeCell` detection is entirely static: it recurses through structs,
+    tuples and the like, but when hitting an `enum` or `union` or so, it treats
+    the entire field as an `UnsafeCell` unless its type is frozen. This avoids
+    hard-to-analyze recursive behavior caused by Stacked Borrows itself doing
+    memory accesses that are subject to Stacked Borrows rules.
 - For immutable raw pointers, the rules are the same as for `Shared`.
 
 So, basically, for every location, we call `grant` like this:

--- a/wip/stacked-borrows.md
+++ b/wip/stacked-borrows.md
@@ -16,6 +16,7 @@ For more background, see the following blog-posts:
 Changes compared to the latest post (2.1):
 
 * Retags are "shallow" instead of recursively looking for references inside compound types.
+* Reborrowing of a shared reference, when searching for `UnsafeCell`, no longer reads enum discriminants. It treats enums like unions now.
 
 [Miri]: https://github.com/solson/miri/
 [all-hands]: https://paper.dropbox.com/doc/Topic-Stacked-borrows--AXAkoFfUGViWL_PaSryqKK~hAg-2q57v4UM7cIkxCq9PQc22


### PR DESCRIPTION
Update the docs to match https://github.com/rust-lang/miri/pull/931.