### PR TITLE
Change note about usize incompatibility with C type

### DIFF
--- a/reference/src/layout/scalars.md
+++ b/reference/src/layout/scalars.md
@@ -37,14 +37,14 @@ The `isize` and `usize` types are pointer-sized signed and unsigned integers.
 They have the same layout as the [pointer types] for which the pointee is
 `Sized`, and are layout compatible with C's `uintptr_t` and `intptr_t` types.
 
+> **Note**: As a result, Rust's `usize` is **not** necessarily layout
+> compatible with C's `size_t`, since `uintptr_t` may be different from
+> `size_t`.
+
 > **Note**: C99 [7.18.2.4](https://port70.net/~nsz/c/c99/n1256.html#7.18.2.4)
 > requires `uintptr_t` and `intptr_t` to be at least 16-bit wide. All 
 > platforms we currently support have a C platform, and as a consequence,
 > `isize`/`usize` are at least 16-bit wide for all of them.
-
-> **Note**: Rust's `usize` and C's `unsigned` types are **not** equivalent. C's
-> `unsigned` is at least as large as a short, allowed to have padding bits, etc.
-> but it is not necessarily pointer-sized.
 
 > **Note**: in the current Rust implementation, the layouts of `isize` and
 > `usize` determine the following:


### PR DESCRIPTION
...to mention `size_t` rather than `unsigned`.

Neither `size_t` nor `unsigned` is guaranteed to be compatible with `usize`, so we could have the note mention both.  But as I see it, when experienced C programmers see `usize` for the first time, they will think of `size_t`, since it has a similar name and is used for similar purposes.  At that point they will be unsurprised to hear that `usize` is different from `unsigned` since, on the most common platforms in use, `size_t` is 64-bit while `unsigned` is 32-bit.  As such, the existing warning doesn't add all that much.  On the other hand, I believe `usize` is compatible with `size_t` on all currently supported targets, so the fact that it might be incompatible is much more surprising.  So surprising, in fact, that I think it's worth removing the mention of `unsigned` just to make the warning stand out more.  YMMV...