### PR TITLE
RFC: Interfacing LLVM's "atomic volatile" in Rust

### DIFF
--- a/rfcs/0000-atomic-volatile.md
+++ b/rfcs/0000-atomic-volatile.md
@@ -292,7 +292,7 @@ impl VolatileBool {
 
     // NOTE: Unlike with `AtomicBool`, `get_mut()` and `into_inner()` operations
     //       are not provided, because it is never safe to assume that no one
-    //       is concurrently accessing the atomic data. Alternatively, these
+    //       is concurrently accessing volatile data. As an alternative, these
     //       operations could be provided in an unsafe way, if someone can find
     //       a use case for them.
 

--- a/rfcs/0000-atomic-volatile.md
+++ b/rfcs/0000-atomic-volatile.md
@@ -106,25 +106,24 @@ unsafe fn do_volatile_things(target: NonNull<VolatileU8>) -> u8 {
 }
 ```
 
-Several specificities, however, should be apparent from the above usage example.
-
-First of all, volatile types must be manipulated via pointers, instad of Rust
-references. These unusual and unpleasant ergonomics are necessary in order to
-achieve the desired semantics of manually controlling every access to the target
-memory location, because the mere existence of a Rust reference pointing to a
-memory region allows the Rust compiler to generate memory operations targeting
-this region (be they prefetches, register spills...).
+However, notice that volatile types must be manipulated via pointers, instad of
+Rust references. These unusual and unpleasant ergonomics are necessary in order
+to achieve the desired semantics of manually controlling every access to the
+target memory location, because the mere existence of a Rust reference pointing
+to a memory region allows the Rust compiler to generate memory operations
+targeting this region (be they prefetches, register spills...).
 
 Because a Rust pointer is not subjected to borrow checking and has no obligation
 of pointing towards a valid memory location, this means that using a Volatile
 wrapper in any way is unsafe.
 
-Second, in addition to familiar atomic memory operations, volatile types expose
-the `load_not_atomic()` and `store_not_atomic()` methods. As their name suggest,
-these memory operations are not considered to be atomic by the compiler, and
-are therefore not safe to concurrently invoke in multiple threads.
+As a second difference, in addition to familiar atomic memory operations,
+volatile types expose the `load_not_atomic()` and `store_not_atomic()` methods.
+As their name suggest, these memory operations are not considered to be atomic
+by the compiler, and are therefore not safe to concurrently invoke in multiple
+threads.
 
-On the vast majority of hardware platforms supported by Rust, using these
+On the vast majority of targets supported by Rust, however, use of these
 methods will generate exactly the same code as using the `load()` and `store()`
 methods with `Relaxed` memory ordering, with the only difference being that
 data races are Undefined Behavior. When that is the case, safer `Relaxed` atomic

--- a/rfcs/0000-atomic-volatile.md
+++ b/rfcs/0000-atomic-volatile.md
@@ -446,9 +446,6 @@ do the same thing, which is equally bad. It could be argued that the issues with
 the existing volatile operations, while real, do not warrant the full complexity
 of this RFC.
 
-Atomic volatile operations are also a somewhat LLVM-specific concept, and
-requiring them may make the life of our other compiler backends harder.
-
 As mentioned above, exposing more than loads and stores, and non-`Relaxed`
 atomic memory orderings, also muddies the "a volatile op should compile into one
 hardware memory instruction" narrative that is so convenient for loads and stores.
@@ -465,7 +462,7 @@ operations as a future extension.
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
 
-This effprt seems worthwhile because it simultaneously eliminates two well-known
+This effort seems worthwhile because it simultaneously eliminates two well-known
 and unnecessary volatile footguns (data races and tearing) and opens interesting
 new possibilities in interprocess communication.
 

--- a/rfcs/0000-atomic-volatile.md
+++ b/rfcs/0000-atomic-volatile.md
@@ -133,7 +133,7 @@ their non-atomic equivalents.
 
 Unfortunately, however, not all of Rust's compilation targets exhibit global
 cache coherence. GPU hardware, such as the `nvptx` target, may only exhibit
-cache coherence among local "blocks" of threads, and abstract machines like WASM
+cache coherence among local "blocks" of threads. And abstract machines like WASM
 may not guarantee cache coherence at all without specific precautions. On those
 compilation targets, `Relaxed` loads and stores may either be unavailable, or
 lead to the generation of multiple machine instructions, which may not be wanted

--- a/rfcs/0000-atomic-volatile.md
+++ b/rfcs/0000-atomic-volatile.md
@@ -501,12 +501,13 @@ atomic orderings in the non-volatile case. This would mean adding one third
 
 Finally, it is extremely common to want either all operations on a memory
 location to be volatile, or none of them. Providing separate wrapper types
-helps enforce this very common usage pattern at the API level. If a need for
-mixed volatile and non-volatile operations on a given memory location ever
-emerges, we could envision providing a new `VolatileXyz` method that casts from
-`NonNull<VolatileXyz>` to `&AtomicXyz`, with a warning to the user that doing so
-voids the warranty of no out-of-thin-air memory operations that normally comes
-attached to `VolatileXyz`.
+helps enforce this very common usage pattern at the API level.
+
+If a need for mixed volatile and non-volatile operations on a given memory
+location ever emerges, we could envision providing a new `VolatileXyz` method
+that casts from `NonNull<VolatileXyz>` to `&AtomicXyz`, with a clear warning in
+its documentation that doing so voids the warranty of no out-of-thin-air memory
+operations that `VolatileXyz` tries to hard to provide.
 
 ## Self-type or not self-type
 [self-type]: #self-type

--- a/rfcs/0000-atomic-volatile.md
+++ b/rfcs/0000-atomic-volatile.md
@@ -51,10 +51,13 @@ trusting Rust programs, through lock-free synchronization of shared memory.
 [guide-level-explanation]: #guide-level-explanation
 
 The Rust compiler generally assumes that the program that it is building is
-living in a fully isolated memory space. It leverages this knowledge to
-transform said program's memory access patterns for performance optimization
-purposes, under the assumption that said transformations will not have any
-externally observable effect other than the program running faster.
+living in a fully isolated memory space, where the contents of memory can only
+change if some direct action from the program allows it to change.
+
+It leverages this knowledge to transform said program's memory access patterns
+for performance optimization purposes, under the assumption that said
+transformations will not have any externally observable effect other than
+speeding up the program.
 
 Examples of such transformations include:
 

--- a/rfcs/0000-atomic-volatile.md
+++ b/rfcs/0000-atomic-volatile.md
@@ -20,7 +20,7 @@ operations on every platform that has support for them.
 Volatile operations are meant to be an escape hatch that allows a Rust
 programmer to invoke hardware-level memory access semantics that are not
 properly accounted for by the Rust Abstract Machine. They work by triggering the
-(mostly) unoptimized generation of a matching stream of hardware load and store
+largely unoptimized generation of a matching stream of hardware load and store
 instructions in the output machine code.
 
 Unfortunately, the volatile operations that are currently exposed by Rust, which
@@ -70,10 +70,12 @@ some situations where they are inappropriate, in areas such as:
   low-level communication protocol between CPUs and peripherals, where hardware
   registers masquerading as memory can be used to program peripherals by
   accessing said registers in very specific load/store patterns.
-- [Shared memory](https://en.wikipedia.org/wiki/Shared_memory), a form of
+- [Shared-memory IPC](https://en.wikipedia.org/wiki/Shared_memory), a form of
   inter-process communication where two programs can communicate via a common
   memory block, which means that stores are externally observable and loads are
-  not guaranteed to return consistent results.
+  not guaranteed to return consistent results. This is not to be confused with
+  shared-memory concurrency, which refers to sharing of memory between multiple
+  threads running within the same process.
 - Advanced uses of [virtual memory](https://en.wikipedia.org/wiki/Virtual_memory)
   where the mere action of reading from or writing to memory may trigger
   execution of arbitrary code by the operating system.
@@ -506,10 +508,10 @@ operations as inherent methods, i.e. `VolatileU8::load(a, Ordering::Relaxed)`.
 
 This has the advantage of avoiding coupling this feature to another unstable
 feature. But it has the drawback of being incredibly verbose. Typing the same
-volatile type name over and over again in a complex shared memory transaction
-would certainly get old and turn annoying quickly, and we don't want anger to
-distract low-level developers from the delicate task of implementing the kind
-of subtle algorithm that requires volatile operations.
+volatile type name over and over again in a complex transaction would certainly
+get old and turn annoying quickly, and we don't want anger to distract low-level
+developers from the delicate task of implementing the kind of subtle algorithm
+that requires volatile operations.
 
 ## `NonNull<T>` vs `*mut T` vs `*const T` vs other
 [pointers]: #pointers
@@ -635,7 +637,7 @@ volatile memory accesses.
   the mere presence of atomics acts as a trigger that disables the above
   optimizations.
 
-## Untrusted shared memory
+## Untrusted shared-memory IPC
 
 Although it performs a step in the right direction by strengthening the
 definition of volatile accesses to result the amount of possible avenues for
@@ -659,8 +661,8 @@ researched before stabilizing that subset of this RFC.
 [future-possibilities]: #future-possibilities
 
 As mentioned above, this RFC is a step forward in addressing the untrusted
-shared memory use case that is of interest to many "supervisor" programs, but
-not the end of that story. Finishing it will likely require LLVM assistance.
+shared-memory IPC use case that is of interest to many "supervisor" programs,
+but not the end of that story. Finishing it will likely require LLVM assistance.
 
 If we decide to drop advanced atomic orderings and operations from this RFC,
 then they will fall out in this section.

--- a/rfcs/0000-atomic-volatile.md
+++ b/rfcs/0000-atomic-volatile.md
@@ -496,7 +496,7 @@ the region is determined to be unobservable to other threads). This would be
 incompatible with the stated goal of precisely controlling memory accesses.
 
 Currently, the only alternative to references in Rust is to use raw pointer
-types. Rust has a number of these, here it is proposes to use `NonNull<T>`
+types. Rust has a number of these, here it is proposed to use `NonNull<T>`
 pointer type because it encodes the non-nullness invariant of the API in code.
 Although `NonNull<T>` is often less ergonomic to manipulate than `*mut T`, the
 use of arbitrary self types make its ergonomics comparable in this case.

--- a/rfcs/0000-atomic-volatile.md
+++ b/rfcs/0000-atomic-volatile.md
@@ -61,10 +61,10 @@ speeding up the program.
 
 Examples of such transformations include:
 
-- Caching data from RAM into CPU registers.
-- Eliminating unused loads and unobservable stores.
-- Merging neighboring stores with each other.
-- Only updating the part of an over-written struct that has actually changed.
+- caching data from RAM into CPU registers,
+- eliminating unused loads and unobservable stores,
+- merging neighboring stores with each other,
+- only updating the part of an over-written struct that has actually changed.
 
 Although these optimizations are most of the time correct and useful, there are
 some situations where they are inappropriate, including but not limited to:
@@ -109,7 +109,7 @@ unsafe fn do_volatile_things(target: NonNull<VolatileU8>) -> u8 {
 }
 ```
 
-However, notice that volatile types must be manipulated via pointers, instead of
+Notice that volatile types must be manipulated via pointers, instead of
 Rust references. These unusual and unpleasant ergonomics are necessary in order
 to achieve the desired semantics of manually controlling every access to the
 target memory location, because the mere existence of a Rust reference pointing

--- a/rfcs/0000-atomic-volatile.md
+++ b/rfcs/0000-atomic-volatile.md
@@ -437,7 +437,7 @@ alternatives section of this RFC.
 
 ---
 
-As currently designed, this RFC uses `arbitrary_safe_types` to give method-like
+As currently designed, this RFC uses `arbitrary_self_types` to give method-like
 semantics to a `NonNull` raw pointer. This seems necessary to get reasonable
 ergonomics with an atomics-like wrapper type approach. However, it could also be
 argued that a `VolatileXyz::store(ptr, data, ordering)` style of API would work

--- a/rfcs/0000-atomic-volatile.md
+++ b/rfcs/0000-atomic-volatile.md
@@ -702,10 +702,11 @@ translated into hardware semantics is much more difficult to reason about, and
 may not be stable across compiler versions and architecture/ABI revisions.
 
 So far, the only use case that was found for these operations was to exert
-stronger control over atomic operation emission, on a hypothetical backend
-which would optimize atomics aggressively. This use case does not seem like it
-would require the full constraints of the `VolatileXyz` API, and it could
-therefore probably be turned into an extension of `std::sync::atomic::Ordering`.
+stronger control over atomic operation emission, on a hypothetical compiler
+which would [optimize atomics too aggressively](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0062r1.html).
+This use case does not seem like it would require the full constraints of the
+`VolatileXyz` API, and it could therefore probably be turned into an extension
+of `std::sync::atomic::Ordering`.
 
 One possibility would be to duplicate every ordering with a volatile variant
 (e.g. `RelaxedVolatile`, `AcquireVolatile...`). Another possibility would be to

--- a/rfcs/0000-atomic-volatile.md
+++ b/rfcs/0000-atomic-volatile.md
@@ -560,14 +560,12 @@ one could split this feature into three feature gates:
 # Prior art
 [prior-art]: #prior-art
 
-To the RFC author's knowledge, LLVM's notion of atomic volatile, which is being
-exposed here, is rather original. The closest thing that it reminds of is how
-Java uses the `volatile` keyword for what most other languages call atomics. But
-it does Java's `volatile` also retains the other semantics of `volatile` in the
-C family, such as lack of optimizability?
+Atomic volatile accesses exist in C++11 and C11. They are respectively exposed
+in those languages as [volatile overloads of `std::atomic` operations](https://en.cppreference.com/w/cpp/atomic/atomic/exchange) and [just making all atomic operations operate on
+volatile objects](https://en.cppreference.com/w/c/atomic/atomic_load).
 
-There is a lot more prior art behind C's notion of volatile, which is closer to
-Rust's current notion of volatile. That being said, most discussions of C/++
+There is also a lot of prior art behind C's notion of volatile, which is closer
+to Rust's current notion of volatile. That being said, most discussions of C/++
 volatile semantics end up in complaints about how ill-specified, how easy it is
 to get it wrong, how "contagious" it can get... so it isn't clear if it is a
 very good role model to follow. Furthermore, Rust's notion of volatile differs

--- a/rfcs/0000-atomic-volatile.md
+++ b/rfcs/0000-atomic-volatile.md
@@ -87,7 +87,7 @@ guarantee that memory loads and stores do occur, because they have externally
 observable side-effects outside of the Rust program being optimized, and may be
 subjected to unpredictable side-effects from the outside world.
 
-And in that cas, it is useful to be able to assert precise manual control on the
+And in that case, it is useful to be able to assert precise manual control on the
 memory accesses that are carried out by a Rust program in a certain memory
 region. This is the purpose of _volatile memory operations_, which allow a Rust
 programmers to generate a carefully controlled stream of hardware memory load

--- a/rfcs/0000-atomic-volatile.md
+++ b/rfcs/0000-atomic-volatile.md
@@ -17,10 +17,10 @@ operations on every platform that has support for them.
 # Motivation
 [motivation]: #motivation
 
-Volatile operations are meant an escape hatch that allows a Rust programmer to
-invoke hardware-level memory access semantics that are not properly accounted
-for by the Rust Abstract Machine. They work by triggering the (mostly)
-unoptimized generation of a matching stream of hardware load and store
+Volatile operations are meant to be an escape hatch that allows a Rust
+programmer to invoke hardware-level memory access semantics that are not
+properly accounted for by the Rust Abstract Machine. They work by triggering the
+(mostly) unoptimized generation of a matching stream of hardware load and store
 instructions in the output machine code.
 
 Unfortunately, the volatile operations that are currently exposed by Rust, which
@@ -67,9 +67,9 @@ Although these optimizations are most of the time correct and useful, there are
 some situations where they are inappropriate, including but not limited to:
 
 - [Memory-mapped I/O](https://en.wikipedia.org/wiki/Memory-mapped_I/O), a common
-  low-level communication pattern between CPUs and peripherals where hardware
-  registers that masquerade as memory can be used to program the target hardware
-  by accessing them in very specific patterns.
+  low-level communication protocol between CPUs and peripherals, where hardware
+  registers masquerading as memory can be used to program said hardware by
+  accessing the registers in very specific load/store patterns.
 - [Shared memory](https://en.wikipedia.org/wiki/Shared_memory), a form of
   inter-process communication where two programs can communicate via a common
   memory block, and it is therefore not appropriate for Rust to assume that it
@@ -157,7 +157,7 @@ unsafe fn do_volatile_things(_target: NonNull<VolatileU8>) -> u8 {
 
 This is the definining characteristic of volatile operations, which makes them
 suitable for sensitive memory manipulations such as cryptographic secret erasure
-or memory-mapped user.
+or memory-mapped I/O.
 
 ---
 
@@ -179,11 +179,11 @@ which is now _deprecated_, by improving upon it in many different ways:
   into multiple hardware-level memory operations. In the same manner as with
   atomics, if a `Volatile` wrapper type is provided by Rust, the underlying
   hardware is guaranteed to support memory operations of that width.
-- The ability to specify stronger-than-`Relaxed` memory orderings on volatile
-  memory operations enables new use cases which were not achievable before
-  without exploiting Undefined Behavior, such as high-performance
-  synchronization of mutually trusting Rust processes communicating via
-  lock-free data structures in shared memory.
+- The ability to specify stronger-than-`Relaxed` memory orderings and to use 
+  memory operations other than loads and stores enables new use cases which were
+  not achievable before without exploiting Undefined Behavior, such as
+  high-performance synchronization of mutually trusting Rust processes
+  via lock-free data structures in shared memory.
 
 
 # Reference-level explanation
@@ -386,6 +386,10 @@ This last case, in particular, could be served through a combination of atomic
 volatile with a clarification of LLVM's volatile semantics which would tune down
 the amount of situations in which a volatile read from memory can be undefined
 behavior.
+
+There are plenty of crates trying to abstract volatile operations. Many are
+believed to be unsound due as they expose an `&self` to the sensitive memory
+region, but `voladdress` is believed not to be affected by this problem.
 
 
 # Unresolved questions

--- a/rfcs/0000-atomic-volatile.md
+++ b/rfcs/0000-atomic-volatile.md
@@ -9,9 +9,9 @@
 Introduce a set of `core::volatile::VolatileXyz` structs, modeled after the
 existing `core::sync::atomic::AtomicXyz` API, which expose volatile loads and
 stores of natively supported width with both atomic and non-atomic semantics.
-Deprecate `ptr::[read|write]_volatile` and the corresponding methods of pointer
-types, and recommend that they be replaced with `Relaxed` atomic volatile
-operations on every platform that has support for them.
+Recommend that `ptr::[read|write]_volatile` and the corresponding methods of
+pointer types be replaced with atomic volatile operations on every platform that
+has support for them.
 
 
 # Motivation
@@ -191,8 +191,8 @@ Experienced Rust users may be familiar with the previously existing
 equivalent methods of raw pointer objects, and wonder how the new facilities
 provided by `std::volatile` compare to those methods.
 
-The answer is that this new volatile data access API supersedes its predecessor,
-which is now _deprecated_, by improving upon it in several ways:
+The answer is that this new volatile data access API should be preferred to its
+predecessor in almost every use case, as it improves upon it in several ways:
 
 - The data race semantics of `Relaxed` volatile data accesses more closely
   matches the data race semantics of most hardware, and therefore eliminates an
@@ -204,6 +204,8 @@ which is now _deprecated_, by improving upon it in several ways:
   into multiple hardware-level memory operations. In the same manner as with
   atomics, if a `Volatile` wrapper type is provided by Rust, the underlying
   hardware is guaranteed to support memory operations of that width.
+- `VolatileXyz` wrappers more strongly encourage developers to refrain from
+  mixing volatile and non-volatile memory accesses, which is usually a mistake.
 - The ability to specify stronger-than-`Relaxed` memory orderings and to use 
   memory operations other than loads and stores enables Rust to draw a clear
   distinction between atomic operations which are meant to synchronize normal
@@ -457,11 +459,11 @@ section of the RFC as well.
 # Drawbacks
 [drawbacks]: #drawbacks
 
-Deprecating the existing volatile operations will cause language churn. Not
-deprecating them will keep around two different and subtly incompatible ways to
-do the same thing, which is equally bad. It could be argued that the issues with
-the existing volatile operations, while real, do not warrant the full complexity
-of this RFC.
+Keeping around two different and subtly incompatible ways to do almost the same
+thing, in the form of these new wrappers and the old volatile read/write methods
+of pointer types, is unsatisfying. It could be argued that the issues with the
+existing volatile operations, while real, do not warrant the full complexity of
+this RFC.
 
 As mentioned above, exposing more than loads and stores, and non-`Relaxed`
 atomic memory orderings, also muddies the "a volatile op should compile into one
@@ -675,3 +677,10 @@ then they will fall out in this section.
 
 This RFC would also benefit from a safer way to interact with volatile memory
 regions than raw pointers.
+
+Finally, one could consider `ptr::[read|write]_volatile` and the corresponding
+methods of pointer types as candidates for future deprecation, as they provide
+less clear semantics than atomic volatile accesses (e.g. no guarantee of being
+exempted from the definition of data races) for no clear benefit. As a more
+backward-compatible alternative, one could also reimplement those methods using
+a loop of atomic volatile operations of unspecified width.

--- a/rfcs/0000-atomic-volatile.md
+++ b/rfcs/0000-atomic-volatile.md
@@ -594,10 +594,6 @@ region, but `voladdress` is believed not to be affected by this problem.
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
 
-The RFC process will be an occasion to revisit some points of the rationale and
-alternative sections better than the author can do on his own, bring new
-arguments and edge cases on the table, and more generally refining the API.
-
 If we decide to implement this, implementation should be reasonably
 straightforward and uneventful, as most of the groundwork has already been done
 over the course of implementing `ptr::read_volatile()`, `ptr::write_volatile()`

--- a/rfcs/0000-atomic-volatile.md
+++ b/rfcs/0000-atomic-volatile.md
@@ -224,10 +224,18 @@ or stronger semantics. The vast majority of hardware which Rust supports today
 and is expected to support in the future exhibits global cache coherence,
 so making volatile feel more at home on such hardware is a sizeable achievement.
 
-However, we obviously must still have something for those exotic platforms whose
-basic memory loads and stores are not cache-coherent, such as `nvptx`. Hence the
-compromise of `load_not_atomic()` and `store_not_atomic()` is still kept around,
-only discouraging its use.
+For exotic platforms whose basic memory loads and stores do not guarantee global
+cache coherence, such as `nvptx`, this RFC adds `load_not_atomic()` and
+`store_not_atomic()` operations. It is unclear at this point in time whether
+these two methods should be stabilized, or an alternative solution such as
+extending Rust's atomic operation model with synchronization guarantees weaker
+than `Relaxed` should be researched.
+
+As this feels like a complex and niche edge case that should not block the most
+generally useful subset of volatile atomic operations, this RFC proposes to
+implement these operations behind a different feature gate, and postpone their
+stabilization until supplementary research has determined whether they are
+truly a necessary evil or not.
 
 ---
 
@@ -596,6 +604,10 @@ doing so also requires work on clarifying LLVM semantics so that it is
 absolutely clear that a malicious process cannot cause UB in another process
 by writing data in memory that's shared between the two, no matter if said
 writes are non-atomic, non-volatile, etc.
+
+The necessity of having `load_not_atomic()` and `store_not_atomic()` methods,
+as opposed to alternatives such as weaker-than-`Relaxed` atomics, should be
+researched before stabilizing that subset of this RFC.
 
 
 # Future possibilities

--- a/rfcs/0000-atomic-volatile.md
+++ b/rfcs/0000-atomic-volatile.md
@@ -33,7 +33,7 @@ memory access semantics of mainstream hardware in two major ways:
 2. Using an overly wide volatile load or store operation which cannot be carried
    out by a single hardware load and store instruction will not result in a
    compilation error, but in the silent emission of multiple hardware load or
-   store instructions.
+   store instructions which might be a logic error in the users' program.
 
 By implementing support for LLVM's atomic volatile operations, and encouraging
 their use on every hardware that supports them, we eliminate these divergences

--- a/rfcs/0000-atomic-volatile.md
+++ b/rfcs/0000-atomic-volatile.md
@@ -303,6 +303,10 @@ jarring to users, not to mention that potentially having a copy of each atomic
 memory operation with a `_volatile` prefix would get annoying quickly when
 reading through the API docs.
 
+Finally, it is extremely common to want either all operations on a memory
+location to be volatile, or none of them. Providing separate wrapper types
+helps enforce this very common usage pattern at the API level.
+
 ## Self-type or not self-type
 [self-type]: #self-type
 

--- a/rfcs/0000-atomic-volatile.md
+++ b/rfcs/0000-atomic-volatile.md
@@ -1,0 +1,416 @@
+- Feature Name: `atomic_volatile`
+- Start Date: 2019-10-15
+- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- Rust Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
+
+# Summary
+[summary]: #summary
+
+Introduce a set of `core::volatile::VolatileXyz` structs, modeled after the
+existing `core::sync::atomic::AtomicXyz` API, which expose volatile loads and
+stores of natively supported width with both atomic and non-atomic semantics.
+Deprecate `ptr::[read|write]_volatile` and the corresponding methods of pointer
+types, and recommend that they be replaced with `Relaxed` atomic volatile
+operations on every platform that has support for them.
+
+
+# Motivation
+[motivation]: #motivation
+
+Volatile operations are meant an escape hatch that allows a Rust programmer to
+invoke hardware-level memory access semantics that are not properly accounted
+for by the Rust Abstract Machine. They work by triggering the (mostly)
+unoptimized generation of a matching stream of hardware load and store
+instructions in the output machine code.
+
+Unfortunately, the volatile operations that are currently exposed by Rust, which
+map into LLVM's non-atomic volatile operations, unnecessarily differ from the
+memory access semantics of mainstream hardware in two major ways:
+
+1. Concurrent use of volatile memory operations on a given memory location is
+   considered to be Undefined Behavior, and may therefore result in unintended
+   compilation output if detected by the optimizer.
+2. Using an overly wide volatile load or store operation which cannot be carried
+   out by a single hardware load and store instruction will not result in a
+   compilation error, but in the silent emission of multiple hardware load or
+   store instructions.
+
+By implementing support for LLVM's atomic volatile operations, and encouraging
+their use on every hardware that supports them, we eliminate these divergences
+from hardware behavior and therefore bring volatile operations closer to the
+"defer to hardware memory model" semantics that programmers expect them to have.
+This reduces the odd of mistake in programs operating outside of the regular
+Rust Abstract Machine semantics, which are notoriously hard to get right.
+
+As an attractive side-effect, atomic volatile memory operations also enable
+higher-performance interprocess communication between mutually trusting Rust
+programs through lock-free synchronization of shared memory objects.
+
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+The Rust compiler generally assumes that the program that it is building is
+living in a fully isolated memory space. It leverages this knowledge to
+transform said program's memory access patterns for performance optimization
+purposes, under the assumption that said transformations will not have any
+externally observable effect other than the program running faster.
+
+Examples of such transformations include:
+
+- Caching data from RAM into CPU registers.
+- Eliminating unused loads and unobservable stores.
+- Merging neighboring stores with each other.
+- Only updating the part of an over-written struct that has actually changed.
+
+Although these optimizations are most of the time correct and useful, there are
+some situations where they are inappropriate, including but not limited to:
+
+- [Memory-mapped I/O](https://en.wikipedia.org/wiki/Memory-mapped_I/O), a common
+  low-level communication pattern between CPUs and peripherals where hardware
+  registers that masquerade as memory can be used to program the target hardware
+  by accessing them in very specific patterns.
+- [Shared memory](https://en.wikipedia.org/wiki/Shared_memory), a form of
+  inter-process communication where two programs can communicate via a common
+  memory block, and it is therefore not appropriate for Rust to assume that it
+  is aware of all memory accesses occurring inside said memory block.
+- [Cryptography](https://en.wikipedia.org/wiki/Cryptography), where it is
+  extremely important to ensure that sensitive information is erased after use,
+  and is not leaked via indirect means such as recognizable scaling patterns in
+  the time taken by a system to process attacker-crafted inputs.
+
+In such circumstances, it may be necessary to assert precise manual control on
+the memory accesses that are carried out by a Rust program in a certain memory
+region. This is the purpose of _volatile memory operations_, which allow a Rust
+programmers to generate a carefully controlled stream of hardware memory load
+and store instructions, which is guaranteed to be left untouched by the Rust
+compiler's optimizer even though surrounding Rust code will continue to be
+optimized as usual.
+
+---
+
+Volatile memory operations are exposed in the `std::volatile` module of the Rust
+standard library, or alternatively in the `core::volatile` module for the
+purpose of writing `#![no_std]` applications. They are interfaced through
+fixed-size data wrappers that are somewhat reminiscent of the API used for
+atomic operations in `std::sync::atomic`:
+
+```rust
+use std::sync::atomic::Ordering;
+use std::ptr::NonNull;
+use std::volatile::VolatileU8;
+
+unsafe fn do_volatile_things(target: NonNull<VolatileU8>) -> u8 {
+    target.store(42, Ordering::Relaxed);
+    target.load_not_atomic()
+}
+```
+
+Several specificities, however, should be apparent from the above usage example.
+
+First of all, volatile types must be manipulated via pointers, instad of Rust
+references. These unusual and unpleasant ergonomics are necessary in order to
+achieve the desired semantics of manually controlling every access to the target
+memory location, because the mere existence of a Rust reference pointing to a
+memory region allows the Rust compiler to generate memory operations targeting
+this region (be they prefetches, register spills...).
+
+Because a Rust pointer is not subjected to borrow checking and has no obligation
+of pointing towards a valid memory location, this means that using a Volatile
+wrapper in any way is unsafe.
+
+Second, in addition to familiar atomic memory operations, volatile types expose
+the `load_not_atomic()` and `store_not_atomic()` methods. As their name suggest,
+these memory operations are not considered to be atomic by the compiler, and
+are therefore not safe to concurrently invoke in multiple threads.
+
+On the vast majority of hardware platforms supported by Rust, using these
+methods will generate exactly the same code as using the `load()` and `store()`
+methods with `Relaxed` memory ordering, with the only difference being that
+data races are Undefined Behavior. When that is the case, safer `Relaxed` atomic
+volatile operations should be preferred to their non-atomic equivalents.
+
+But unfortunately, Rust supports a couple of platforms, such as the `nvptx`
+assembly used by NVidia GPUs, where `Relaxed` atomic ordering is either
+unsupported or emulated via a stream of hardware instructions that is more
+complex than plain loads and stores. Supporting not-atomic volatile loads and
+stores is necessary to get minimal `Volatile` support on those platforms.
+
+Finally, unlike with atomics, the compiler is not allowed to optimize the above
+function into the following...
+
+```rust
+unsafe fn do_volatile_things(target: NonNull<VolatileU8>) -> u8 {
+    target.store(42, Ordering::Relaxed);
+    42
+}
+```
+
+...or even the following, if it can prove that no other thread has access to
+the underlying `VolatileU8` variable:
+
+```rust
+unsafe fn do_volatile_things(_target: NonNull<VolatileU8>) -> u8 {
+    42
+}
+```
+
+This is the definining characteristic of volatile operations, which makes them
+suitable for sensitive memory manipulations such as cryptographic secret erasure
+or memory-mapped user.
+
+---
+
+Experienced Rust users may be familiar with the previously existing
+`std::ptr::read_volatile()` and `std::ptr::write_volatile()` functions, or
+equivalent methods of raw pointer objects, and wonder how the new facilities
+provided by `std::volatile` compare to those methods.
+
+The answer is that this new volatile data access API supersedes its predecessor,
+which is now _deprecated_, by improving upon it in many different ways:
+
+- The data race semantics of `Relaxed` volatile data accesses more closely
+  matches the data race semantics of most hardware, and therefore eliminates an
+  unnecessary mismatch between volatile semantics and low-level hardware load
+  and store semantics when it comes to concurrency.
+- `VolatileXyz` wrappers are only supported for data types which are supported
+  at the machine level. Therefore, one no longer needs to worry about the
+  possibility of the compiler silently turning a Rust-level volatile data access
+  into multiple hardware-level memory operations. In the same manner as with
+  atomics, if a `Volatile` wrapper type is provided by Rust, the underlying
+  hardware is guaranteed to support memory operations of that width.
+- The ability to specify stronger-than-`Relaxed` memory orderings on volatile
+  memory operations enables new use cases which were not achievable before
+  without exploiting Undefined Behavior, such as high-performance
+  synchronization of mutually trusting Rust processes communicating via
+  lock-free data structures in shared memory.
+
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+The fundamental purpose of volatile operations, in a system programming language
+like Rust, is to allow a developer to locally escape the Rust Abstract Machine's
+weak memory semantics and defer to the hardware's memory semantics instead,
+without resorting to the full complexity, overhead, and non-portability of
+assembly (inline or otherwise).
+
+Rust's current volatile operations, which defer to LLVM's non-atomic volatile
+operations, do not achieve this goal very well because...
+
+1. Their data race semantics do not match the data race semantics of the
+   hardware which volatile is supposed to defer to, and as a result are
+   unnecessarily surprising and unsafe. They prevent some synchronization
+   patterns which are legal at the hardware level but not at the abstract
+   machine level, such as the "seqlock", to be expressed using volatile
+   operations. No useful optimization opportunities are opened by this undefined
+   behavior, since volatile operations cannot be meaningfully optimized.
+2. The absence of a hard guarantee that each volatile load or store will
+   translate into exactly one load or store at the hardware level is needlessly
+   tracherous in scenarios where memory access patterns must be very precisely
+   controlled, such as memory-mapped I/O.
+
+Using LLVM's `Relaxed` atomic volatile operations instead resolves both problems
+on cache-coherent hardware where native loads and stores have `Relaxed` or
+stronger semantics. The vast majority of hardware which Rust supports today and
+is expected to support in the future is cache-coherent, and therefore making
+volatile feel more at home on such hardware is a major win.
+
+However, we obviously must still have something for those exotic platforms whose
+basic memory loads and stores are not cache-coherent, such as `nvptx`. Hence the
+compromise of `load_not_atomic()` and `store_not_atomic()` is still kept around,
+only discouraging its use.
+
+---
+
+It should be noted that switching to LLVM's atomic volatile accesses does not
+resolve the second problem very well per se, because although oversized volatile
+accesses will not compile anymore, they will only be "reported" to the user via
+LLVM crashes. This is not a nice user experience, which is why volatile wrapper
+types are proposed.
+
+Their design largely mirrors that of Rust's existing atomic types, which is only
+appropriate since they do expose atomic operations. One goal of this design is
+that it should be possible to re-use the architecture-specific code that already
+exists to selectively expose Rust atomic types and operations depending on what
+the hardware supports under the hood.
+
+---
+
+This RFC currently proposes to expose the full power of LLVM's atomic volatile
+operations, including e.g. read-modify-write operations like compare-and-swap,
+because there are legitimately useful use cases for these operations in
+interprocess communication scenarios.
+
+However, the fact that these operations do not necessarily compile into a single
+hardware instruction is arguably a footgun for volatile's use cases, and it
+could be argued that initially only stabilizing loads, stores and `Relaxed`
+atomic ordering would be more prudent. I'll go back to this in the alternatives
+section of this RFC.
+
+---
+
+As currently designed, this RFC uses `arbitrary_safe_types` to give method-like
+semantics to a `NonNull` raw pointer. I believe that this is necessary to get
+reasonable ergonomics with an atomics-like wrapper type approach. However, it
+could also be argued that a `VolatileXyz::store(ptr, data, ordering)` style of
+API could reasonably work, and avoid coupling with unstable features. Similarly,
+the use of `NonNull` itself could be debated. I'll come back to these points in
+the alternatives section as well.
+
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+Deprecating the existing volatile operations will cause language churn. Not
+deprecating them will keep around two different and subtly incompatible ways to
+do the same thing, which is equally bad. It could be argued that the issues with
+the existing volatile operations, while real, do not warrant the full complexity
+of this RFC.
+
+Atomic volatile operations are also a somewhat LLVM-specific concept, and
+requiring them may make the life of our other compiler backends harder.
+
+As mentioned above, exposing more than loads and stores, and non-`Relaxed`
+atomic memory orderings, also muddies the "a volatile op should compile into one
+hardware memory instruction" that is so convenient for loads and stores.
+Further, compatibility of non-load/store atomics in IPC scenario may require
+some ABI agreement between the interacting programs.
+
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+I think we want to do this because it simultaneously eliminates two well-known
+and unnecessary volatile footguns (data races and tearing) and opens interesting
+new possibilities.
+
+But although this feature may seem simple, its design space is actually
+remarquably large, and a great many alternatives were considered before reaching
+the current design proposal. Here is a map of some design knobs that I explored:
+
+## Extending `AtomicXyz`
+[extending-atomicxyz]: #extending-atomicxyz
+
+Atomic volatile operations could be made part of the Atomic wrapper types.
+However, they cannot be just another atomic memory ordering, due to the fact
+that atomic ops take an `&self` (which is against the spirit of volatile as it
+is tagged with `dereferenceable` at the LLVM layer).
+
+Instead, one would need to add more methods to atomic wrapper types, which take
+a pointer as a self-parameter. I thought that this API inconsistency would be
+jarring to users, not to mention that potentially having a copy of each atomic
+memory operation with a `_volatile` prefix would get annoying quickly when
+reading through the API docs.
+
+## Self-type or not self-type
+[self-type]: #self-type
+
+Instead of using `arbitrary_self_types` to get `a.load(Ordering::Relaxed)`
+method syntax on pointer-like objects, one could instead provide the volatile
+operations as inherent methods, i.e. `VolatileU8::load(a, Ordering::Relaxed)`.
+
+This has the advantage of avoiding coupling this feature to another unstable
+feature. But it has the drawback of being incredibly verbose. Typing the same
+volatile type name over and over again in a complex shared memory transaction
+would certainly get old and turn annoying quickly, and we don't want anger to
+distract low-level developers from the delicate task of implementing the kind
+of subtle algorithm that requires volatile operations.
+
+## `NonNull<T>` vs `*mut T` vs `*const T` vs other
+[pointers]: #pointers
+
+Honestly, I don't have a very strong opinion there. I have a positive _a priori_
+towards `NonNull<T>` because it encodes an important invariant in the API, and
+I think that arbitrary self types make its usually poor ergonomics bearable.
+
+But what I would really want here is something like a non-`dereferenceable`
+Rust reference. I don't like the fact that I have to give up on the borrow
+checker and make everything unsafe just to do volatile loads and stores, which
+are not unsafe _per se_ as long as they occur via a `Volatile` wrapper. It just
+feels like we should be able to propose something better than full references
+vs full raw pointers here...
+
+## Full atomics vocabulary vs hardware semantics
+[atomics-vs-hardware]: #atomics-vs-hardware
+
+Currently, this RFC basically proposes exposing a volatile version of every
+atomic operation supported by Rust for maximal expressive power, and I could
+definitely find uses for the new possibilities that this opens in IPC scenarios.
+
+But it could also be argued that this distracts us from volatile's main purpose
+of generating a stream of simple hardware instructions without using inline
+assembly:
+
+- Non-`Relaxed` atomics will entail memory barriers
+- Compare-and-swap may be implemented as a load-linked/store-conditional loop
+- Some types like `VolatileBool` are dangerous when interacting with untrusted
+  code because they come with data validity invariants.
+
+From this perspective, there would be an argument in favor of only supporting
+`Relaxed` load/stores and machine data types, at least initially. And I could
+get behind that. But since the rest can be useful in IPC with trusted Rust code,
+I thought it might be worth at least considering.
+
+
+# Prior art
+[prior-art]: #prior-art
+
+As far as I know, LLVM's notion of atomic volatile, which is being exposed here,
+is rather original. The closest thing that it makes me think about is how Java
+uses the `volatile` keyword for what most other languages call atomics. But
+I'm not sure if Java also retains the other semantics of `volatile` in the C
+family (e.g. "cannot be optimized out ever").
+
+There is a lot more prior art behind C's notion of volatile, which is closer to
+Rust's current notion of volatile. That being said, most discussions of C/++
+volatile semantics end up in complaints about how ill-specified, how easy it is
+to get it wrong, how "contagious" it can get... so I'm not sure if it's
+something we want to emulate. Besides, Rust's notion of volatile differs
+fundamentally from C's notion of volatile in that it is based on volatile
+_operations_, not volatile _types_.
+
+In the C++ community, there have been
+[a series](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p1152r0.html)
+[of papers](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1152r2.html)
+by JF Bastien to greatly reduce the scope of `volatile`, ideally until it
+basically covers just loads and stores.
+
+In the Rust community, we have a long history of discussing use cases that
+require volatile semantics, from
+[memory-mapped I/O](https://github.com/rust-lang/unsafe-code-guidelines/issues/33)
+to [weird virtual memory](https://github.com/rust-lang/unsafe-code-guidelines/issues/28)
+and [interaction with untrusted system processes](https://github.com/rust-lang/unsafe-code-guidelines/issues/152).
+
+This last case, in particular, could be served through a combination of atomic
+volatile with a clarification of LLVM's volatile semantics which would tune down
+the amount of situations in which a volatile read from memory can be undefined
+behavior.
+
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+I expect the RFC process to be an occasion to revisit some points of the
+rationale and alternative sections better than I can do on my own, bring new
+arguments and edge cases on the table, and more generally refine the API.
+
+Implementation should be generally straightforward as most of the groundwork
+has already been done when implementing `ptr::read_volatile()`,
+`ptr::write_volatile()` and `std::sync::atomic` as far as I know.
+
+This RFC will no fully resolve the "untrusted shared memory" use case, because
+doing so also requires work on clarifying LLVM semantics so that it is
+absolutely clear that a malicious process cannot cause UB in another process
+by writing data in memory that's shared between the two, no matter if said
+writes are non-atomic, non-volatile, etc.
+
+
+# Future possibilities
+[future-possibilities]: #future-possibilities
+
+If we decide to drop advanced atomic orderings and operations from this RFC,
+then they will fall out in this section.
+
+This RFC would also benefit from a safer way to interact with volatile memory
+regions than raw pointers.

--- a/rfcs/0000-atomic-volatile.md
+++ b/rfcs/0000-atomic-volatile.md
@@ -202,7 +202,8 @@ which is now _deprecated_, by improving upon it in several ways:
   Rust code and atomic operations which are meant to synchronize with arbitrary
   FFI edge cases (such as threads spawned by LD_PRELOAD unbeknownst to the Rust
   compiler), which in turn would enable better optimization of atomic operations
-  in the vast majority of Rust programs.
+  in the vast majority of Rust programs, as will be further discussed in the
+  Unresolved Questions section.
 
 
 # Reference-level explanation

--- a/rfcs/0000-atomic-volatile.md
+++ b/rfcs/0000-atomic-volatile.md
@@ -59,6 +59,7 @@ speeding up the program.
 Examples of such transformations include:
 
 - caching data from RAM into CPU registers,
+- spilling CPU registers into accessible RAM locations,
 - eliminating unused loads and unobservable stores,
 - merging neighboring stores with each other,
 - only updating the part of an over-written struct that has actually changed.

--- a/rfcs/0000-atomic-volatile.md
+++ b/rfcs/0000-atomic-volatile.md
@@ -106,7 +106,7 @@ unsafe fn do_volatile_things(target: NonNull<VolatileU8>) -> u8 {
 }
 ```
 
-However, notice that volatile types must be manipulated via pointers, instad of
+However, notice that volatile types must be manipulated via pointers, instead of
 Rust references. These unusual and unpleasant ergonomics are necessary in order
 to achieve the desired semantics of manually controlling every access to the
 target memory location, because the mere existence of a Rust reference pointing

--- a/rfcs/0000-atomic-volatile.md
+++ b/rfcs/0000-atomic-volatile.md
@@ -181,7 +181,7 @@ unsafe fn do_volatile_things(_target: NonNull<VolatileU8>) -> u8 {
 The fact that hardware loads and stores must be emitted even when the compiler's
 optimizer can predict the results of loads or assert that stores will have no
 effect on program execution is one of the most central characteristics of
-volatile operations, it is what makes these operations suitable for sensitive
+volatile operations. It is what makes these operations suitable for sensitive
 memory manipulations such as cryptographic secret erasure or memory-mapped I/O.
 
 ---

--- a/rfcs/0000-atomic-volatile.md
+++ b/rfcs/0000-atomic-volatile.md
@@ -196,7 +196,7 @@ without resorting to the full complexity, overhead, and non-portability of
 assembly (inline or otherwise).
 
 Rust's current volatile operations, which defer to LLVM's non-atomic volatile
-operations, do not achieve this goal very well because...
+operations, do not achieve this goal very well because:
 
 1. Their data race semantics do not match the data race semantics of the
    hardware which volatile is supposed to defer to, and as a result are

--- a/rfcs/0000-atomic-volatile.md
+++ b/rfcs/0000-atomic-volatile.md
@@ -93,8 +93,8 @@ guarantee that memory loads and stores do occur, because they have externally
 observable side-effects outside of the Rust program being optimized, and may be
 subjected to unpredictable side-effects from the outside world.
 
-And in that case, it is useful to be able to assert precise manual control on the
-memory accesses that are carried out by a Rust program in a certain memory
+And in that case, it is useful to be able to assert precise manual control on
+the memory accesses that are carried out by a Rust program in a certain memory
 region. This is the purpose of _volatile memory operations_, which allow a Rust
 programmers to generate a carefully controlled stream of hardware memory load
 and store instructions, which is guaranteed to be left untouched by the Rust
@@ -178,9 +178,11 @@ unsafe fn do_volatile_things(_target: NonNull<VolatileU8>) -> u8 {
 }
 ```
 
-This is the definining characteristic of volatile operations, which makes them
-suitable for sensitive memory manipulations such as cryptographic secret erasure
-or memory-mapped I/O.
+The fact that hardware loads and stores must be emitted even when the compiler's
+optimizer can predict the results of loads or assert that stores will have no
+effect on program execution is one of the most central characteristics of
+volatile operations, it is what makes these operations suitable for sensitive
+memory manipulations such as cryptographic secret erasure or memory-mapped I/O.
 
 ---
 
@@ -644,7 +646,7 @@ volatile memory accesses.
 ## Untrusted shared-memory IPC
 
 Although it performs a step in the right direction by strengthening the
-definition of volatile accesses to result the amount of possible avenues for
+definition of volatile accesses to reduce the amount of possible avenues for
 undefined behavior, this RFC will no fully resolve the "untrusted shared memory"
 use case, where Rust code is interacting with untrusted arbitrary code via a
 shared memory region.

--- a/rfcs/0000-atomic-volatile.md
+++ b/rfcs/0000-atomic-volatile.md
@@ -119,7 +119,7 @@ Rust references. These unusual and unpleasant ergonomics are necessary in order
 to achieve the desired semantics of manually controlling every access to the
 target memory location, because the mere existence of a Rust reference pointing
 to a memory region allows the Rust compiler to generate memory operations
-targeting this region (be they prefetches, register spills...).
+targeting this region (be they prefetches, register spills, ...).
 
 Because a Rust pointer is not subjected to borrow checking and has no obligation
 of pointing towards a valid memory location, this means that using a Volatile

--- a/rfcs/0000-atomic-volatile.md
+++ b/rfcs/0000-atomic-volatile.md
@@ -399,9 +399,10 @@ I expect the RFC process to be an occasion to revisit some points of the
 rationale and alternative sections better than I can do on my own, bring new
 arguments and edge cases on the table, and more generally refine the API.
 
-Implementation should be generally straightforward as most of the groundwork
-has already been done when implementing `ptr::read_volatile()`,
-`ptr::write_volatile()` and `std::sync::atomic` as far as I know.
+If we decide to implement this, implementation should be reasonably
+straightforward and uneventful, as most of the groundwork has already been done
+over the course of implementing `ptr::read_volatile()`, `ptr::write_volatile()`
+and `std::sync::atomic` (as far as I know at least).
 
 This RFC will no fully resolve the "untrusted shared memory" use case, because
 doing so also requires work on clarifying LLVM semantics so that it is

--- a/rfcs/0000-atomic-volatile.md
+++ b/rfcs/0000-atomic-volatile.md
@@ -660,7 +660,7 @@ references are automatically marked as `dereferenceable` has caused a some of
 pain recently in the Rust community:
 
 - [Unsoundness and poor ergonomics in embedded crates](https://github.com/rust-embedded/wg/pull/387)
-- [Unsoundness in deallocate-on-drop smart pointers](https://github.com/rust-lang/rust/issues/55005)
+- Unsoundness in deallocate-on-drop smart pointers like [Arc](https://github.com/rust-lang/rust/issues/55005) and [Box](https://github.com/rust-lang/rust/issues/66600)
 
 Therefore, in the author's opinion, it would be most prudent to punt on
 stabilization of this language feature until we have a clearer picture of

--- a/rfcs/0000-atomic-volatile.md
+++ b/rfcs/0000-atomic-volatile.md
@@ -70,7 +70,8 @@ some situations where they are inappropriate, in areas such as:
 - [Memory-mapped I/O](https://en.wikipedia.org/wiki/Memory-mapped_I/O), a common
   low-level communication protocol between CPUs and peripherals, where hardware
   registers masquerading as memory can be used to program peripherals by
-  accessing said registers in very specific load/store patterns.
+  accessing said registers in very specific load/store patterns (possibly
+  coupled with hardware-specific CPU cache configurations and memory barriers).
 - [Shared-memory IPC](https://en.wikipedia.org/wiki/Shared_memory), a form of
   inter-process communication where two programs can communicate via a common
   memory block, which means that stores are externally observable and loads are

--- a/rfcs/0000-atomic-volatile.md
+++ b/rfcs/0000-atomic-volatile.md
@@ -80,7 +80,9 @@ some situations where they are inappropriate, in areas such as:
   threads running within the same process.
 - Advanced uses of [virtual memory](https://en.wikipedia.org/wiki/Virtual_memory)
   where the mere action of reading from or writing to memory may trigger
-  execution of arbitrary code by the operating system.
+  execution of arbitrary code by the operating system. Note that even when using
+  volatile accesses, [some sanity restrictions](https://llvm.org/docs/LangRef.html#volatile-memory-accesses)
+  are imposed by LLVM here to allow optimization of surrouding code.
 - [Cryptography](https://en.wikipedia.org/wiki/Cryptography), where it is
   extremely important to ensure that sensitive information is erased after use,
   and is not leaked via indirect means such as recognizable scaling patterns in

--- a/rfcs/0000-atomic-volatile.md
+++ b/rfcs/0000-atomic-volatile.md
@@ -645,6 +645,23 @@ volatile memory accesses.
   the mere presence of atomics acts as a trigger that disables the above
   optimizations.
 
+## Necessity of non-atomic operations
+
+The necessity of having `load_not_atomic()` and `store_not_atomic()` methods,
+as opposed to alternatives such as weaker-than-`Relaxed` atomics, should be
+researched before stabilizing that subset of this RFC.
+
+## Safer self types
+
+This RFC would also benefit from a safer way to interact with volatile memory
+regions than raw pointers, by providing a way to opt out of LLVM's
+"dereferenceable" semantics without also having to opt out from all the
+memory-safety guarantees provided by the Rust borrow checker.
+
+
+# Future possibilities
+[future-possibilities]: #future-possibilities
+
 ## Untrusted shared-memory IPC
 
 Although it performs a step in the right direction by strengthening the
@@ -658,25 +675,12 @@ absolutely clear that a malicious process cannot cause UB in another process by
 by writing data in memory that's shared between the two, no matter if said
 writes are non-atomic, non-volatile, etc.
 
-## Necessity of non-atomic operations
-
-The necessity of having `load_not_atomic()` and `store_not_atomic()` methods,
-as opposed to alternatives such as weaker-than-`Relaxed` atomics, should be
-researched before stabilizing that subset of this RFC.
-
-
-# Future possibilities
-[future-possibilities]: #future-possibilities
-
-As mentioned above, this RFC is a step forward in addressing the untrusted
-shared-memory IPC use case that is of interest to many "supervisor" programs,
-but not the end of that story. Finishing it will likely require LLVM assistance.
+## Volatile atomic operations
 
 If we decide to drop advanced atomic orderings and operations from this RFC,
 then they will fall out in this section.
 
-This RFC would also benefit from a safer way to interact with volatile memory
-regions than raw pointers.
+## Deprecating `ptr::[read|write]_volatile`
 
 Finally, one could consider `ptr::[read|write]_volatile` and the corresponding
 methods of pointer types as candidates for future deprecation, as they provide


### PR DESCRIPTION
Basically my proposal to move forward on volatile support in Rust, by interfacing LLVM's atomic volatile which I consider to be a better match for volatile's intended "defer to hardware memory model" semantics than today's `ptr::[read|write]_volatile` in every single respect.

Emerges from the #152 discussion, and a step toward resolving it, but will not fully resolve that problem because as far as I know, that's impossible without LLVM involvement.

Having this RFC reviewed here is intended as a way to weed out obvious problems in a small and focused group before going for the broader audience of a pre-RFC on IRLO.

[Rendered](https://github.com/HadrienG2/unsafe-code-guidelines/blob/atomic-volatile/rfcs/0000-atomic-volatile.md)