### PR TITLE
add case of libstd fix from Stacked Borrows

### DIFF
--- a/wip/stacked-borrows.md
+++ b/wip/stacked-borrows.md
@@ -348,3 +348,4 @@ libstd needed/needs some patches to comply with this model. These provide a good
 * [`BTreeMap` creating mutable references that overlap with shared references](https://github.com/rust-lang/rust/pull/58431)
 * [`LinkedList` creating overlapping mutable references](https://github.com/rust-lang/rust/pull/60072)
 * [`VecDeque` invalidates a protected shared reference](https://github.com/rust-lang/rust/issues/60076)
+* [Windows `Env` iterator creating `*const T` from `&T` to read memory outside of `T`](https://github.com/rust-lang/rust/pull/70479)


### PR DESCRIPTION
This PR adds a new case to the list of
**'adjustments made to libstd (due to Stacked Borrows violation)'**.

A small fix was made to libstd in rust-lang/rust#70479 (back in March).
(Miri reported UB due to Stacked Borrows violation - [link to Miri error log](https://github.com/rust-lang/miri/pull/1225#discussion_r397830221))

Thank you for reviewing :+1: