### PR TITLE
Add missing `repr(C)` to a struct exposed to C

### DIFF
--- a/reference/src/layout/function-pointers.md
+++ b/reference/src/layout/function-pointers.md
@@ -86,6 +86,8 @@ bool for_all(struct Cons const *self, bool (*func)(int, void *), void *thunk);
 #    os::raw::c_int,
 # };
 #
+
+#[repr(C)]
 pub struct Cons {
   data: c_int,
   next: Option<Box<Cons>>,


### PR DESCRIPTION
This struct is supposed to be shared between Rust and C code, but suspiciously lacks `#[repr(C)]`.