### PR TITLE
Disambiguate wording on array size/stride

### DIFF
--- a/reference/src/layout/arrays-and-slices.md
+++ b/reference/src/layout/arrays-and-slices.md
@@ -76,8 +76,8 @@ struct A(u16, u8);
 type B = [A; 4];
 ```
 
-In the current Rust implementation, `A` has an alignment and a size of `4`, and
-`B` has a size of `16`, such that `B` contains four `A`s that are contiguously
+In the current Rust implementation, `A` has an alignment of `2` and a size of `4`,
+and `B` has a size of `16`, such that `B` contains four `A`s that are contiguously
 laid in memory. 
 
 However, a future Rust implementation could implement a layout optimization that


### PR DESCRIPTION
In the current text:

> ```rust
> struct A(u16, u8);
> ```
> `A` has an alignment and a size of `4`

I read this as saying:

* `A` has an alignment of `4` and
* `A` has a size of `4`

This is not correct. `struct A(u16, u8)` has an alignment of `2`.

Perhaps it was really saying:

* `A` has a specified alignment (which we don't state the value of here) and
* `A` has a size of `4`

This is correct, but a bit confusing.

This proposed change makes the wording less ambiguous.