### PR TITLE
Add triagebot support

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,0 +1,10 @@
+[relabel]
+allow-unauthenticated = [
+    "A-*",
+    "C-*",
+    "S-*",
+    "T-*",
+ ]
+
+# Gives us the commands 'ready', 'author', 'blocked'
+[shortcut]


### PR DESCRIPTION
This enables triagebot on the unsafe-code-guidelines repository and creates triagebot.toml.

Currently all label groups are covered by `allow-unauthenticated`